### PR TITLE
fix: Update image class from 'object-cover' to 'object-fit' for bette…

### DIFF
--- a/src/component/Hero.tsx
+++ b/src/component/Hero.tsx
@@ -81,7 +81,7 @@ const Hero: React.FC = () => {
                 <img 
                   src={nextEvent.imageUrl} 
                   alt={nextEvent.name} 
-                  className="absolute inset-0 w-full h-full object-cover" 
+                  className="absolute inset-0 w-full h-full object-fit" 
                 />
               ) : (
                 <div className="absolute inset-0 bg-gradient-to-br from-gray-800 to-gray-900" />


### PR DESCRIPTION
This pull request makes a minor update to the styling of the event image in the `Hero` component. The CSS class for the image was changed to use `object-fit` instead of `object-cover`, which may affect how the image is displayed within its container.

* Updated the `className` of the event image in `Hero.tsx` to use `object-fit` for image rendering.…r responsiveness