### PR TITLE
feat: Allow corporate teams and individual categories in one registra…

### DIFF
--- a/src/component/badminton/StepEntries.tsx
+++ b/src/component/badminton/StepEntries.tsx
@@ -33,9 +33,6 @@ export default function StepEntries() {
   const [players, setPlayers] = useState<Player[]>([]);
   const [error, setError] = useState<string | null>(null);
 
-  const hasTeamEntry = state.entries.some((e) => CATEGORY_BY_CODE[e.category].exclusive);
-  const hasIndividualEntry = state.entries.some((e) => !CATEGORY_BY_CODE[e.category].exclusive);
-
   const total = useMemo(
     () => state.entries.reduce((sum, e) => sum + CATEGORY_BY_CODE[e.category].fee, 0),
     [state.entries]
@@ -43,16 +40,9 @@ export default function StepEntries() {
 
   const meta = selected ? CATEGORY_BY_CODE[selected] : null;
 
-  function isDisabled(code: BadmintonCategory): boolean {
-    const m = CATEGORY_BY_CODE[code];
-    // A team entry locks the whole registration; individual entries lock team.
-    if (hasTeamEntry) return true;
-    if (m.exclusive && hasIndividualEntry) return true;
-    return false;
-  }
-
+  // Any mix of categories is allowed, including several corporate teams, so no
+  // category is ever locked out.
   function selectCategory(code: BadmintonCategory) {
-    if (isDisabled(code)) return;
     if (selected === code) {
       closeForm();
       return;
@@ -162,26 +152,40 @@ export default function StepEntries() {
                   <motion.div
                     key={e.id}
                     {...listAnim}
-                    className="glass-panel-subtle p-3 flex items-start justify-between gap-3"
+                    className="glass-panel-subtle p-4 flex items-start justify-between gap-4"
                   >
-                    <div className="min-w-0">
-                      <p className="text-sm font-semibold text-gray-900 dark:text-white truncate">
+                    <div className="min-w-0 space-y-1.5">
+                      <p className="text-base font-semibold text-gray-900 dark:text-white leading-snug">
                         {em.label}
-                        {e.teamName ? ` — ${e.teamName}` : ""}
                       </p>
-                      {e.players.length > 0 && (
-                        <p className="text-xs text-gray-600 dark:text-gray-300 mt-0.5 truncate">
-                          {e.players.map((p) => p.name).join(", ")}
+                      {e.teamName && (
+                        <p className="text-sm text-gray-700 dark:text-gray-200">
+                          <span className="text-gray-500 dark:text-gray-400">Team:</span>{" "}
+                          <span className="font-medium">{e.teamName}</span>
+                        </p>
+                      )}
+                      {e.players.length > 0 ? (
+                        <ul className="space-y-0.5">
+                          {e.players.map((p, i) => (
+                            <li key={i} className="text-sm text-gray-600 dark:text-gray-300 break-words">
+                              {p.name}
+                              <span className="text-gray-400 dark:text-gray-500"> · {p.phone}</span>
+                            </li>
+                          ))}
+                        </ul>
+                      ) : (
+                        <p className="text-sm text-gray-500 dark:text-gray-400">
+                          Roster shared before the Captains' Meeting.
                         </p>
                       )}
                     </div>
-                    <div className="flex items-center gap-3 shrink-0">
-                      <span className="text-sm font-medium text-brand-lime">{formatINR(em.fee)}</span>
+                    <div className="flex flex-col items-end gap-2 shrink-0">
+                      <span className="text-base font-bold text-brand-lime">{formatINR(em.fee)}</span>
                       <button
                         type="button"
                         onClick={() => dispatch({ type: "REMOVE_ENTRY", payload: e.id })}
-                        className="text-xs text-red-600 hover:underline"
-                        aria-label={`Remove ${em.label}`}
+                        className="rounded-full border border-red-300 dark:border-red-500/40 text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-500/10 text-xs font-medium px-3 py-1.5 transition-colors"
+                        aria-label={`Remove ${em.label}${e.teamName ? ` — ${e.teamName}` : ""}`}
                       >
                         Remove
                       </button>
@@ -205,20 +209,17 @@ export default function StepEntries() {
         </h3>
         <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
           {BADMINTON_CATEGORIES.map((c) => {
-            const disabled = isDisabled(c.code);
             const active = selected === c.code;
             return (
               <motion.button
                 key={c.code}
                 type="button"
                 onClick={() => selectCategory(c.code)}
-                disabled={disabled}
                 aria-pressed={active}
-                {...(reduceMotion || disabled ? {} : { whileHover: { y: -2 }, whileTap: { scale: 0.97 } })}
+                {...(reduceMotion ? {} : { whileHover: { y: -2 }, whileTap: { scale: 0.97 } })}
                 className={[
-                  "glass-panel p-3 sm:p-4 text-left transition-all duration-200",
+                  "glass-panel p-3 sm:p-4 text-left transition-all duration-200 glass-hover cursor-pointer",
                   active ? "ring-2 ring-brand-lime shadow-lg" : "",
-                  disabled ? "opacity-40 cursor-not-allowed" : "glass-hover cursor-pointer",
                 ].join(" ")}
               >
                 <p className="text-sm font-semibold text-gray-900 dark:text-white leading-snug">{c.label}</p>
@@ -232,18 +233,10 @@ export default function StepEntries() {
             );
           })}
         </div>
-        {hasTeamEntry && (
-          <p className="text-[11px] text-gray-500 dark:text-gray-400 mt-2">
-            Corporate Team registrations cannot be combined with other entries. Remove the team entry
-            to add individual categories.
-          </p>
-        )}
-        {!hasTeamEntry && hasIndividualEntry && (
-          <p className="text-[11px] text-gray-500 dark:text-gray-400 mt-2">
-            The Corporate Team Event cannot be combined with individual entries — it needs a separate
-            registration.
-          </p>
-        )}
+        <p className="text-[11px] text-gray-500 dark:text-gray-400 mt-2">
+          Add as many categories as you like — corporate teams and individual entries can be
+          combined in a single registration.
+        </p>
       </div>
 
       {/* Focused entry form */}
@@ -281,9 +274,17 @@ export default function StepEntries() {
                     <button
                       type="button"
                       onClick={useContactForFirst}
-                      className="text-xs text-brand-lime hover:underline"
+                      className="glass-button-outline inline-flex items-center gap-2 text-sm px-4 py-2"
                     >
-                      Use primary contact details for Player 1
+                      <svg
+                        className="w-4 h-4 shrink-0"
+                        viewBox="0 0 20 20"
+                        fill="currentColor"
+                        aria-hidden="true"
+                      >
+                        <path d="M10 8a3 3 0 100-6 3 3 0 000 6zM3.465 14.493a1.23 1.23 0 00.41 1.412A9.957 9.957 0 0010 18c2.31 0 4.438-.784 6.131-2.1.43-.333.604-.903.408-1.41a7.002 7.002 0 00-13.074.003z" />
+                      </svg>
+                      Autofill Player 1 with my contact details
                     </button>
                   )}
 

--- a/src/constants/badminton.ts
+++ b/src/constants/badminton.ts
@@ -23,17 +23,15 @@ export type CategoryMeta = {
   unit: string;
   /** Whether the entry form collects per-player details for this category. */
   collectsPlayers: boolean;
-  /** Exclusive categories cannot be combined with any other entry. */
-  exclusive: boolean;
   /** For mixed doubles: hint that one male + one female is expected. */
   note?: string;
 };
 
 export const BADMINTON_CATEGORIES: CategoryMeta[] = [
-  { code: "mens_singles", label: "Men's Singles", fee: 150000, players: 1, unit: "per entry", collectsPlayers: true, exclusive: false },
-  { code: "womens_singles", label: "Women's Singles", fee: 150000, players: 1, unit: "per entry", collectsPlayers: true, exclusive: false },
-  { code: "mens_doubles", label: "Men's Doubles", fee: 300000, players: 2, unit: "per team", collectsPlayers: true, exclusive: false },
-  { code: "womens_doubles", label: "Women's Doubles", fee: 300000, players: 2, unit: "per team", collectsPlayers: true, exclusive: false },
+  { code: "mens_singles", label: "Men's Singles", fee: 150000, players: 1, unit: "per entry", collectsPlayers: true },
+  { code: "womens_singles", label: "Women's Singles", fee: 150000, players: 1, unit: "per entry", collectsPlayers: true },
+  { code: "mens_doubles", label: "Men's Doubles", fee: 300000, players: 2, unit: "per team", collectsPlayers: true },
+  { code: "womens_doubles", label: "Women's Doubles", fee: 300000, players: 2, unit: "per team", collectsPlayers: true },
   {
     code: "mixed_doubles",
     label: "Mixed Doubles",
@@ -41,7 +39,6 @@ export const BADMINTON_CATEGORIES: CategoryMeta[] = [
     players: 2,
     unit: "per team",
     collectsPlayers: true,
-    exclusive: false,
     note: "One male and one female player.",
   },
   {
@@ -51,7 +48,6 @@ export const BADMINTON_CATEGORIES: CategoryMeta[] = [
     players: [2, 4],
     unit: "per team",
     collectsPlayers: false,
-    exclusive: true,
     note: "2 Singles + 1 Doubles per tie, 2–4 players. Only the team name is needed now; the roster is collected before the Captains' Meeting.",
   },
 ];

--- a/supabase/functions/_shared/badminton.ts
+++ b/supabase/functions/_shared/badminton.ts
@@ -11,9 +11,8 @@ export const FEE_MAP: Record<string, number> = {
   team_event: 500000,
 };
 
-// Allowed player counts per category: [min, max]. The team event collects no
-// player details — only a team name — and is exclusive: it cannot be combined
-// with any other entry in the same registration.
+// Allowed player counts per category: [min, max]. The team event is absent by
+// design — it collects only a team name, not a roster.
 export const PLAYER_BOUNDS: Record<string, [number, number]> = {
   mens_singles: [1, 1],
   womens_singles: [1, 1],

--- a/supabase/functions/_shared/registration.test.ts
+++ b/supabase/functions/_shared/registration.test.ts
@@ -23,23 +23,53 @@ Deno.test("valid team-only passes", () => {
   assertEquals(validate(org, [{ category: "team_event", teamName: "Smashers", players: [] }]), null);
 });
 
-Deno.test("team mixed with individual is rejected", () => {
+// A company can enter a corporate team and individual categories together.
+Deno.test("team mixed with individual passes", () => {
   assertEquals(
     validate(org, [
       { category: "team_event", teamName: "Smashers", players: [] },
       { category: "womens_singles", players: [player] },
     ]),
-    "Corporate Team Event cannot be combined with other categories"
+    null
   );
 });
 
-Deno.test("two team entries rejected", () => {
+Deno.test("two team entries pass", () => {
   assertEquals(
     validate(org, [
-      { category: "team_event", teamName: "A", players: [] },
-      { category: "team_event", teamName: "B", players: [] },
+      { category: "team_event", teamName: "Acme A", players: [] },
+      { category: "team_event", teamName: "Acme B", players: [] },
     ]),
-    "Corporate Team Event cannot be combined with other categories"
+    null
+  );
+});
+
+// Entries are validated individually, so a team entry earlier in the list must
+// not let a later bad entry through.
+Deno.test("a bad entry after a team entry is still rejected", () => {
+  assertEquals(
+    validate(org, [
+      { category: "team_event", teamName: "Smashers", players: [] },
+      { category: "mens_doubles", players: [player] },
+    ]),
+    "Men's Doubles requires 2 player(s)"
+  );
+  assertEquals(
+    validate(org, [
+      { category: "team_event", teamName: "Smashers", players: [] },
+      { category: "not_a_category", players: [] },
+    ]),
+    "Invalid category: not_a_category"
+  );
+});
+
+Deno.test("a team without a name is rejected even when it isn't first", () => {
+  assertEquals(
+    validate(org, [
+      { category: "womens_singles", players: [player] },
+      { category: "team_event", teamName: "", players: [] },
+    ]),
+    "Team name is required for the Corporate Team Event"
   );
 });
 

--- a/supabase/functions/_shared/registration.ts
+++ b/supabase/functions/_shared/registration.ts
@@ -27,22 +27,22 @@ export function validate(organization: any, entries: any[]): string | null {
   if (!Array.isArray(entries) || entries.length === 0) return "No entries provided";
   if (entries.length > MAX_ENTRIES) return "Too many entries";
 
-  // Team Event is exclusive: a registration is either one team entry, or any
-  // mix of individual entries — never both, and never more than one team.
-  const teamEntries = entries.filter((e) => e && e.category === "team_event");
-  if (teamEntries.length > 0) {
-    if (entries.length > 1) {
-      return "Corporate Team Event cannot be combined with other categories";
-    }
-    const team = teamEntries[0];
-    if (!str(team.teamName || "", MAX_SHORT) || String(team.teamName).trim().length < 2) {
-      return "Team name is required for the Corporate Team Event";
-    }
-    return null;
-  }
-
+  // A registration may freely mix corporate team entries with individual
+  // categories, and may contain more than one team — MAX_ENTRIES is the only
+  // cap. Every entry is checked on its own terms below.
   for (const e of entries) {
     if (!e || !FEE_MAP[e.category]) return `Invalid category: ${e && e.category}`;
+
+    // Team entries carry a name instead of a roster — the players are
+    // collected before the Captains' Meeting, so PLAYER_BOUNDS has no entry
+    // for them and the per-player checks below don't apply.
+    if (e.category === "team_event") {
+      if (!str(e.teamName || "", MAX_SHORT) || String(e.teamName).trim().length < 2) {
+        return "Team name is required for the Corporate Team Event";
+      }
+      continue;
+    }
+
     const [min, max] = PLAYER_BOUNDS[e.category];
     if (!Array.isArray(e.players) || e.players.length < min || e.players.length > max) {
       return `${CATEGORY_LABEL[e.category]} requires ${min}${min === max ? "" : `-${max}`} player(s)`;


### PR DESCRIPTION
…tion

A company can now enter the Corporate Team Event alongside individual categories, and can enter more than one team, in a single registration. Previously the team event was exclusive: adding it disabled every other category and vice versa.

The rule lived in two places. Removing it from the UI alone would have left the server rejecting mixed payloads with a 400, so validate() drops the exclusivity branch and folds team handling into the per-entry loop. That also closes a hole: the old code returned early on the first team entry, so anything after it was never validated at all. PLAYER_BOUNDS has no team_event key by design, hence the explicit continue.

Also on step 2, per feedback that both were hard to read:

- "Use primary contact details" was an 11px text link; it is now a visible button with an icon.
- The entries list truncated player names and used a bare "Remove" text link. It is now a card list with the team name on its own line, players wrapping instead of clipped, and a bordered remove control.

