### PR TITLE
fix: Authorize admins by identity, not merely by authentication

### DIFF
--- a/supabase/functions/_shared/auth.test.ts
+++ b/supabase/functions/_shared/auth.test.ts
@@ -1,0 +1,31 @@
+import { assertEquals } from "@std/assert";
+import { isAuthorizedAdmin } from "./auth.ts";
+
+const USER = "6b1f0b6e-0f1a-4f0b-9b6e-0f1a4f0b9b6e";
+const OTHER = "11111111-2222-3333-4444-555555555555";
+
+Deno.test("a user on the allowlist is authorized", () => {
+  assertEquals(isAuthorizedAdmin(USER, [USER, OTHER]), true);
+});
+
+// The bug this whole change exists to fix: before the allowlist, any validly
+// authenticated user passed the admin check.
+Deno.test("an authenticated user not on the allowlist is refused", () => {
+  assertEquals(isAuthorizedAdmin(OTHER, [USER]), false);
+});
+
+// Fail closed, never open — an empty or unavailable allowlist must not be
+// read as "no restrictions".
+Deno.test("an empty allowlist authorizes nobody", () => {
+  assertEquals(isAuthorizedAdmin(USER, []), false);
+});
+
+Deno.test("a missing user id is refused", () => {
+  assertEquals(isAuthorizedAdmin(null, [USER]), false);
+  assertEquals(isAuthorizedAdmin("", [USER]), false);
+});
+
+Deno.test("matching is exact, not by prefix", () => {
+  assertEquals(isAuthorizedAdmin(USER.slice(0, 8), [USER]), false);
+  assertEquals(isAuthorizedAdmin(USER + "x", [USER]), false);
+});

--- a/supabase/functions/_shared/auth.ts
+++ b/supabase/functions/_shared/auth.ts
@@ -1,0 +1,59 @@
+// Admin authorization for the admin-only Edge Functions.
+//
+// Two separate questions, and the old code only asked the first:
+//   1. Is this a real logged-in user?  (resolve the token against GoTrue)
+//   2. Is that user an admin?          (membership in admin_users)
+//
+// `verify_jwt = true` in config.toml only proves the bearer token was signed
+// by this project — the anon key itself is a validly-signed JWT — so step 1
+// still needs the GoTrue round-trip. But step 1 alone authorizes every account
+// in the project, which is exactly the hole the admin_users allowlist closes
+// (see the 20260726192917_admin_authorization migration).
+
+/** Pure — no Deno.*, no network — so the decision is directly unit-testable. */
+export function isAuthorizedAdmin(userId: string | null, adminIds: string[]): boolean {
+  if (!userId) return false;
+  return adminIds.includes(userId);
+}
+
+/** Resolves the bearer token to a user id, or null if it isn't a real session. */
+async function resolveUserId(req: Request): Promise<string | null> {
+  const auth = req.headers.get("authorization") || "";
+  const token = auth.replace(/^Bearer\s+/i, "").trim();
+  if (!token) return null;
+  const res = await fetch(`${Deno.env.get("SUPABASE_URL")}/auth/v1/user`, {
+    headers: {
+      apikey: Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  if (!res.ok) return null;
+  const user = await res.json();
+  return typeof user?.id === "string" ? user.id : null;
+}
+
+/** Reads the allowlist with the service role (admin_users has no RLS policies
+ * at all, so nothing else can see it). */
+async function fetchAdminIds(): Promise<string[]> {
+  const key = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+  const res = await fetch(
+    `${Deno.env.get("SUPABASE_URL")}/rest/v1/admin_users?select=user_id`,
+    { headers: { apikey: key, Authorization: `Bearer ${key}` } }
+  );
+  if (!res.ok) throw new Error(`admin_users lookup failed (${res.status})`);
+  const rows = await res.json();
+  return Array.isArray(rows) ? rows.map((r: { user_id: string }) => r.user_id) : [];
+}
+
+export async function requireAdmin(req: Request): Promise<boolean> {
+  try {
+    const userId = await resolveUserId(req);
+    if (!userId) return false;
+    return isAuthorizedAdmin(userId, await fetchAdminIds());
+  } catch (e) {
+    // Fail closed: if the allowlist can't be read, refuse rather than fall
+    // back to "any authenticated user".
+    console.error("Admin check failed:", (e as Error).message);
+    return false;
+  }
+}

--- a/supabase/functions/regenerate-invoice/index.ts
+++ b/supabase/functions/regenerate-invoice/index.ts
@@ -1,25 +1,9 @@
 // deno-lint-ignore-file no-explicit-any
 import { corsHeaders, isAllowedOrigin } from "../_shared/cors.ts";
 import { generateAndStoreInvoice } from "../_shared/invoice.ts";
+import { requireAdmin } from "../_shared/auth.ts";
 
 const MAX_BODY_BYTES = 2 * 1024;
-
-// `verify_jwt = true` (config.toml) only proves the bearer token was signed
-// by this project — the anon key itself is a validly-signed JWT too, so that
-// alone doesn't prove a real admin session. Resolve the token against GoTrue
-// to confirm it's an actual logged-in user, not just any project JWT.
-async function requireAdmin(req: Request): Promise<boolean> {
-  const auth = req.headers.get("authorization") || "";
-  const token = auth.replace(/^Bearer\s+/i, "").trim();
-  if (!token) return false;
-  const res = await fetch(`${Deno.env.get("SUPABASE_URL")}/auth/v1/user`, {
-    headers: {
-      apikey: Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
-      Authorization: `Bearer ${token}`,
-    },
-  });
-  return res.ok;
-}
 
 export async function handleRequest(req: Request): Promise<Response> {
   const origin = req.headers.get("origin");

--- a/supabase/migrations/20260726192917_admin_authorization.sql
+++ b/supabase/migrations/20260726192917_admin_authorization.sql
@@ -1,0 +1,185 @@
+-- Real admin authorization.
+--
+-- Until now every write policy in this schema authorized on *authentication*
+-- rather than *identity* — the pattern was `to authenticated ... using (true)`,
+-- which grants writes to anyone holding any valid session. There was no admin
+-- table, no role claim, and no check of which user was asking. That was safe
+-- only because the app has no signup screen and public sign-ups are switched
+-- off in the dashboard, i.e. the entire authorization model rested on a
+-- dashboard toggle.
+--
+-- This migration replaces that with an explicit allowlist: admin_users plus an
+-- is_admin() helper, referenced by every write policy.
+--
+-- Chosen over a JWT role claim because it needs no auth hook, is inspectable
+-- with a plain select, and lets admins be granted or revoked without the user
+-- re-authenticating. Note the shortcut NOT taken: a role in
+-- `auth.jwt() ->> 'user_metadata'` would be user-editable — anyone could
+-- promote themselves. Only app_metadata or a table is safe.
+
+-- ---------------------------------------------------------------------------
+-- Allowlist + helpers
+-- ---------------------------------------------------------------------------
+
+create table if not exists admin_users (
+  user_id uuid primary key references auth.users(id) on delete cascade,
+  note text,
+  added_at timestamptz not null default now()
+);
+
+alter table admin_users enable row level security;
+-- No policies, deliberately: service role only. Admins can edit everything
+-- else through the app, but not the list of who is an admin.
+
+-- security definer is what prevents infinite recursion here: the function
+-- reads admin_users without re-triggering that table's own RLS. search_path is
+-- pinned empty so every reference below has to be schema-qualified.
+create or replace function public.is_admin() returns boolean
+  language sql
+  security definer
+  stable
+  set search_path = ''
+as $$
+  select exists (
+    select 1 from public.admin_users where user_id = (select auth.uid())
+  );
+$$;
+
+revoke all on function public.is_admin() from public;
+grant execute on function public.is_admin() to authenticated, service_role;
+
+-- Convenience for the runbook: adding an admin is one call instead of copying
+-- uuids around. Service role only — this is the privilege-granting path.
+create or replace function public.grant_admin(p_email text) returns uuid
+  language plpgsql
+  security definer
+  set search_path = ''
+as $$
+declare
+  v_id uuid;
+begin
+  select id into v_id from auth.users where lower(email) = lower(p_email);
+  if v_id is null then
+    raise exception 'no such user: %', p_email;
+  end if;
+  insert into public.admin_users (user_id, note) values (v_id, lower(p_email))
+    on conflict (user_id) do nothing;
+  return v_id;
+end;
+$$;
+
+revoke all on function public.grant_admin(text) from public, anon, authenticated;
+grant execute on function public.grant_admin(text) to service_role;
+
+-- ---------------------------------------------------------------------------
+-- Seed: grandfather in everyone who already had admin rights.
+--
+-- Every existing user was already an effective admin under the old policies,
+-- so copying them across preserves current behaviour exactly and — more
+-- importantly — guarantees nobody is locked out the moment the policies below
+-- are swapped. On a brand-new project auth.users is empty and this is a no-op;
+-- there, create the admin user and then run: select public.grant_admin('...');
+--
+-- REVIEW `select * from admin_users;` AFTER APPLYING and delete anyone who
+-- should not have write access.
+-- ---------------------------------------------------------------------------
+
+insert into admin_users (user_id, note)
+select id, coalesce(email, '(no email)') from auth.users
+on conflict (user_id) do nothing;
+
+-- ---------------------------------------------------------------------------
+-- Repoint every write policy at is_admin()
+--
+-- Public read policies are intentionally left alone: public read of content
+-- and of payment_settings is by design, and badminton_registrations correctly
+-- has no anon policy at all.
+-- ---------------------------------------------------------------------------
+
+-- Content tables: same loop shape as the original schema migration.
+do $$
+declare t text;
+begin
+  foreach t in array array['events','teams','event_teams','matches','gallery','news','homepage_content']
+  loop
+    execute format('drop policy if exists "admin insert" on %I', t);
+    execute format('drop policy if exists "admin update" on %I', t);
+    execute format('drop policy if exists "admin delete" on %I', t);
+
+    execute format('create policy "admin insert" on %I for insert to authenticated with check (public.is_admin())', t);
+    execute format('create policy "admin update" on %I for update to authenticated using (public.is_admin()) with check (public.is_admin())', t);
+    execute format('create policy "admin delete" on %I for delete to authenticated using (public.is_admin())', t);
+  end loop;
+end $$;
+
+-- Registrations: admin may read and update, never delete (audit trail).
+drop policy if exists "admin read registrations" on badminton_registrations;
+drop policy if exists "admin update registrations" on badminton_registrations;
+
+create policy "admin read registrations"
+  on badminton_registrations for select to authenticated using (public.is_admin());
+create policy "admin update registrations"
+  on badminton_registrations for update to authenticated
+  using (public.is_admin()) with check (public.is_admin());
+
+-- Storage: `media` writes and `invoices` reads.
+drop policy if exists "admin write media" on storage.objects;
+drop policy if exists "admin update media" on storage.objects;
+drop policy if exists "admin delete media" on storage.objects;
+drop policy if exists "admin read invoices" on storage.objects;
+
+create policy "admin write media"
+  on storage.objects for insert to authenticated
+  with check (bucket_id = 'media' and public.is_admin());
+create policy "admin update media"
+  on storage.objects for update to authenticated
+  using (bucket_id = 'media' and public.is_admin());
+create policy "admin delete media"
+  on storage.objects for delete to authenticated
+  using (bucket_id = 'media' and public.is_admin());
+create policy "admin read invoices"
+  on storage.objects for select to authenticated
+  using (bucket_id = 'invoices' and public.is_admin());
+
+-- Invoice settings (admin-only read as well as write).
+drop policy if exists "admin read invoice settings" on invoice_settings;
+drop policy if exists "admin write invoice settings" on invoice_settings;
+drop policy if exists "admin update invoice settings" on invoice_settings;
+
+create policy "admin read invoice settings"
+  on invoice_settings for select to authenticated using (public.is_admin());
+create policy "admin write invoice settings"
+  on invoice_settings for insert to authenticated with check (public.is_admin());
+create policy "admin update invoice settings"
+  on invoice_settings for update to authenticated
+  using (public.is_admin()) with check (public.is_admin());
+
+-- Payment settings: public read stays, writes become admin-only.
+drop policy if exists "admin write payment settings" on payment_settings;
+drop policy if exists "admin update payment settings" on payment_settings;
+
+create policy "admin write payment settings"
+  on payment_settings for insert to authenticated with check (public.is_admin());
+create policy "admin update payment settings"
+  on payment_settings for update to authenticated
+  using (public.is_admin()) with check (public.is_admin());
+
+-- ---------------------------------------------------------------------------
+-- Unrelated but same class of bug: next_invoice_number() is security definer
+-- with an unpinned search_path, so a caller controlling search_path could
+-- resolve the unqualified `invoice_seq` to a sequence of their choosing.
+-- ---------------------------------------------------------------------------
+
+create or replace function next_invoice_number()
+returns text
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  n bigint;
+begin
+  n := nextval('public.invoice_seq');
+  return 'MK-BADM-' || to_char(now(), 'YYYY') || '-' || lpad(n::text, 6, '0');
+end;
+$$;


### PR DESCRIPTION
Every write policy in the schema authorized on authentication rather than identity — `to authenticated ... using (true)` — across 32 policies: the seven content tables, badminton_registrations, storage, and both settings tables. Any account with a valid session could rewrite all of it. The same gap existed in requireAdmin, which resolved the bearer token against GoTrue and returned res.ok: proof of a real logged-in user, never of an authorized one.

That was safe only because the app has no signup screen and public sign-ups are off in the dashboard, which left a dashboard toggle as the whole authorization model. A new Supabase project has sign-ups on by default, so the production project being created would have been one setting away from letting any stranger write.

Adds an admin_users allowlist and an is_admin() helper, referenced by every write policy. Chosen over a JWT role claim because it needs no auth hook and is inspectable with a plain select. Note the shortcut avoided: a role in user_metadata would be user-editable, so anyone could self-promote.

The migration grandfathers every existing user into admin_users before swapping the policies — they were all effective admins already, so this preserves behaviour exactly and makes lockout impossible. Review the table afterwards and revoke anyone who shouldn't be there.

Also pins search_path on next_invoice_number(), which was security definer with an unqualified sequence reference — same class of bug, found nearby.