### PR TITLE
feat: Add the policy pages Razorpay's merchant verification requires

### DIFF
--- a/src/component/Footer.tsx
+++ b/src/component/Footer.tsx
@@ -1,11 +1,15 @@
 import React from "react";
 import { Link } from "react-router-dom";
+import { ORGANISATION } from "../constants/organisation";
+
+const linkClass =
+  "text-sm text-gray-700 dark:text-gray-300 hover:text-lime-600 dark:hover:text-lime-400 transition-colors duration-200";
 
 const Footer: React.FC = () => {
   return (
     <footer className="mt-12 glass-panel-strong border-t border-white/20 dark:border-white/10">
       <div className="mx-auto max-w-6xl px-4 py-10">
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-8">
           {/* Brand */}
           <div>
             <div className="flex items-center gap-2 mb-3">
@@ -20,46 +24,39 @@ const Footer: React.FC = () => {
           {/* Quick Links */}
           <nav aria-label="Quick links" className="grid gap-2 content-start">
             <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-2 drop-shadow-sm">Quick Links</h3>
-            <Link to="/upcoming-events" className="text-sm text-gray-700 dark:text-gray-300 hover:text-lime-600 dark:hover:text-lime-400 transition-colors duration-200">Events</Link>
-            <Link to="/badminton" className="text-sm text-gray-700 dark:text-gray-300 hover:text-lime-600 dark:hover:text-lime-400 transition-colors duration-200">Register</Link>
-            <Link to="/about" className="text-sm text-gray-700 dark:text-gray-300 hover:text-lime-600 dark:hover:text-lime-400 transition-colors duration-200">About</Link>
-            <Link to="/contact" className="text-sm text-gray-700 dark:text-gray-300 hover:text-lime-600 dark:hover:text-lime-400 transition-colors duration-200">Contact</Link>
+            <Link to="/upcoming-events" className={linkClass}>Events</Link>
+            <Link to="/badminton" className={linkClass}>Register</Link>
+            <Link to="/registration/status" className={linkClass}>Registration Status</Link>
+            <Link to="/about" className={linkClass}>About</Link>
+            <Link to="/contact" className={linkClass}>Contact</Link>
           </nav>
 
-          {/* Contact */}
+          {/* Legal. Reachable from every page — Razorpay's merchant verification
+              expects these four to be linked site-wide, not just findable. */}
+          <nav aria-label="Policies" className="grid gap-2 content-start">
+            <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-2 drop-shadow-sm">Legal</h3>
+            <Link to="/terms" className={linkClass}>Terms &amp; Conditions</Link>
+            <Link to="/privacy" className={linkClass}>Privacy Policy</Link>
+            <Link to="/refunds" className={linkClass}>Refund &amp; Cancellation</Link>
+            <Link to="/shipping" className={linkClass}>Shipping &amp; Delivery</Link>
+          </nav>
+
+          {/* Contact. Single-sourced from constants/organisation so this can
+              never drift from /contact or the policy pages again. */}
           <div className="grid gap-2 content-start">
             <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-2 drop-shadow-sm">Contact</h3>
-            <a href="mailto:hello@maharashtrakrida.in" className="text-sm text-gray-700 dark:text-gray-300 hover:text-lime-600 dark:hover:text-lime-400 transition-colors duration-200">hello@maharashtrakrida.in</a>
-            <a href="tel:+919999999999" className="text-sm text-gray-700 dark:text-gray-300 hover:text-lime-600 dark:hover:text-lime-400 transition-colors duration-200">+91 99999 99999</a>
-            <div className="flex gap-3 mt-2" aria-label="Social links">
-              <a
-                href="https://www.instagram.com/"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="glass-button-secondary h-9 w-9 p-0 hover:glass-glow-hover"
-                aria-label="Instagram"
-              >
-                <svg className="h-5 w-5" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
-                  <path d="M7 2h10a5 5 0 0 1 5 5v10a5 5 0 0 1-5 5H7a5 5 0 0 1-5-5V7a5 5 0 0 1 5-5zm0 2a3 3 0 0 0-3 3v10a3 3 0 0 0 3 3h10a3 3 0 0 0 3-3V7a3 3 0 0 0-3-3H7zm5 3a5 5 0 1 1 0 10 5 5 0 0 1 0-10zm0 2.2A2.8 2.8 0 1 0 12 17.8 2.8 2.8 0 0 0 12 9.2zM18 6.3a1 1 0 1 1 0 2.1 1 1 0 0 1 0-2.1z"/>
-                </svg>
-              </a>
-              <a
-                href="https://twitter.com/"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="glass-button-secondary h-9 w-9 p-0 hover:glass-glow-hover"
-                aria-label="Twitter"
-              >
-                <svg className="h-5 w-5" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
-                  <path d="M22.46 6c-.77.35-1.6.58-2.46.69a4.26 4.26 0 0 0 1.87-2.35 8.52 8.52 0 0 1-2.7 1.03 4.24 4.24 0 0 0-7.22 3.87 12.04 12.04 0 0 1-8.74-4.43 4.24 4.24 0 0 0 1.31 5.66 4.2 4.2 0 0 1-1.92-.53v.05c0 2.05 1.46 3.77 3.4 4.17-.36.1-.75.16-1.14.16-.28 0-.55-.03-.81-.08.55 1.72 2.15 2.97 4.04 3a8.51 8.51 0 0 1-6.27 1.75 12 12 0 0 0 6.5 1.9c7.81 0 12.09-6.47 12.09-12.09l-.01-.55A8.64 8.64 0 0 0 22.46 6z"/>
-                </svg>
-              </a>
-            </div>
+            <p className="text-sm text-gray-700 dark:text-gray-300 leading-relaxed">
+              {ORGANISATION.addressLines.map((line) => (
+                <span key={line} className="block">{line}</span>
+              ))}
+            </p>
+            <a href={`mailto:${ORGANISATION.email}`} className={linkClass}>{ORGANISATION.email}</a>
+            <a href={ORGANISATION.phoneHref} className={linkClass}>{ORGANISATION.phone}</a>
           </div>
         </div>
 
         <div className="mt-10 flex flex-col sm:flex-row items-center justify-between gap-3 border-t border-white/20 dark:border-white/10 pt-6">
-          <p className="text-xs text-gray-600 dark:text-gray-400 drop-shadow-sm">© {new Date().getFullYear()} Maharashtra Krida. All rights reserved.</p>
+          <p className="text-xs text-gray-600 dark:text-gray-400 drop-shadow-sm">© {new Date().getFullYear()} {ORGANISATION.legalName}. All rights reserved.</p>
           <div className="text-xs text-gray-600 dark:text-gray-400 drop-shadow-sm">Built with love in Maharashtra.</div>
         </div>
       </div>

--- a/src/component/badminton/StepReview.tsx
+++ b/src/component/badminton/StepReview.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { Link } from "react-router-dom";
 import { useBadmintonRegistration } from "../../hook/useBadmintonRegistration";
 import { CATEGORY_BY_CODE, formatINR } from "../../constants/badminton";
 
@@ -85,7 +86,34 @@ export default function StepReview() {
         <span>
           I understand that entry fees are <strong>strictly non-refundable</strong> and that once
           registered, entries cannot be cancelled or transferred. Registration is confirmed only on
-          receipt of the entry fees.
+          receipt of the entry fees. I accept the{" "}
+          <Link
+            to="/terms"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-lime-600 dark:text-lime-400 hover:underline"
+          >
+            Terms &amp; Conditions
+          </Link>
+          ,{" "}
+          <Link
+            to="/refunds"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-lime-600 dark:text-lime-400 hover:underline"
+          >
+            Refund &amp; Cancellation Policy
+          </Link>{" "}
+          and{" "}
+          <Link
+            to="/privacy"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-lime-600 dark:text-lime-400 hover:underline"
+          >
+            Privacy Policy
+          </Link>
+          .
         </span>
       </label>
 

--- a/src/constants/organisation.ts
+++ b/src/constants/organisation.ts
@@ -1,0 +1,25 @@
+// Who we are, in one place.
+//
+// These details appear in the footer, on /contact, and across the four policy
+// pages that Razorpay's merchant verification checks. They were previously
+// hardcoded per-file, which is how the footer ended up advertising a
+// placeholder phone number that contradicted /contact — exactly the kind of
+// inconsistency that gets a merchant application sent back.
+//
+// Mirrored server-side by ORGANIZER in supabase/functions/_shared/invoice.ts,
+// which stamps the invoice PDF. Deno and Vite cannot share a module, so the two
+// have to be edited together — same contract as the fee tables.
+
+export const ORGANISATION = {
+  legalName: "Maharashtra Krida",
+  addressLines: ["OM SAI Palace", "Narhe, Sinhagad Road", "Pune 411 041"],
+  contactName: "Ashwin Panhalkar",
+  phone: "+91 9890 171 195",
+  phoneHref: "tel:+919890171195",
+  email: "maharashtrakrida@gmail.com",
+  /** Shown on every policy page. Bump when the policy text materially changes. */
+  policiesLastUpdated: "29 July 2026",
+} as const;
+
+/** "OM SAI Palace, Narhe, Sinhagad Road, Pune 411 041" — for inline prose. */
+export const ADDRESS_INLINE = ORGANISATION.addressLines.join(", ");

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { ORGANISATION } from "../constants/organisation";
 
 const Contact: React.FC = () => {
   return (
@@ -13,23 +14,23 @@ const Contact: React.FC = () => {
           <div className="glass-panel p-5">
             <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Address</h2>
             <p className="mt-2 text-sm text-gray-700 dark:text-gray-300 leading-relaxed">
-              OM SAI Palace,
-              <br /> Narhe, Sinhagad Road,
-              <br /> Pune 411 041
+              {ORGANISATION.addressLines.map((line) => (
+                <span key={line} className="block">{line}</span>
+              ))}
             </p>
           </div>
 
           <div className="glass-panel p-5">
             <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Call</h2>
             <p className="mt-2 text-sm text-gray-700 dark:text-gray-300">
-              Contact Person: <span className="font-medium">Ashwin Panhalkar</span>
+              Contact Person: <span className="font-medium">{ORGANISATION.contactName}</span>
             </p>
-            <a href="tel:+919890171195" className="mt-1 inline-block text-sm text-lime-600 dark:text-lime-400 hover:underline">+91 9890 171 195</a>
+            <a href={ORGANISATION.phoneHref} className="mt-1 inline-block text-sm text-lime-600 dark:text-lime-400 hover:underline">{ORGANISATION.phone}</a>
           </div>
 
           <div className="glass-panel p-5">
             <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Email</h2>
-            <a href="mailto:maharashtrakrida@gmail.com" className="mt-2 inline-block text-sm text-lime-600 dark:text-lime-400 hover:underline">maharashtrakrida@gmail.com</a>
+            <a href={`mailto:${ORGANISATION.email}`} className="mt-2 inline-block text-sm text-lime-600 dark:text-lime-400 hover:underline">{ORGANISATION.email}</a>
             <p className="mt-2 text-xs text-gray-600 dark:text-gray-400">We usually respond within 1–2 business days.</p>
           </div>
         </div>
@@ -46,7 +47,7 @@ const Contact: React.FC = () => {
               const subj = encodeURIComponent(String(fd.get("subject") || "Inquiry"));
               const body = encodeURIComponent(String(fd.get("message") || ""));
               const footer = rawName ? `%0D%0A%0D%0ARegards,%20${encodeURIComponent(rawName)}` : "";
-              window.location.href = `mailto:maharashtrakrida@gmail.com?subject=${subj}&body=${body}${footer}`;
+              window.location.href = `mailto:${ORGANISATION.email}?subject=${subj}&body=${body}${footer}`;
               (e.currentTarget as HTMLFormElement).reset();
             }}
           >

--- a/src/pages/legal/LegalPage.tsx
+++ b/src/pages/legal/LegalPage.tsx
@@ -1,0 +1,90 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import { ADDRESS_INLINE, ORGANISATION } from "../../constants/organisation";
+
+/**
+ * Shared shell for the four policy pages Razorpay's merchant verification looks
+ * for. Keeps them visually consistent with /about and /contact, and puts the
+ * "last updated" line and the contact block in one place so they can never
+ * disagree between pages.
+ */
+
+type Props = {
+  title: string;
+  /** One-line summary shown under the heading. */
+  intro: string;
+  children: React.ReactNode;
+};
+
+export function Section({ heading, children }: { heading: string; children: React.ReactNode }) {
+  return (
+    <section className="mt-6 first:mt-0">
+      <h2 className="text-lg font-semibold text-gray-900 dark:text-white">{heading}</h2>
+      <div className="mt-2 space-y-3 text-sm text-gray-700 dark:text-gray-300 leading-relaxed">
+        {children}
+      </div>
+    </section>
+  );
+}
+
+export function List({ items }: { items: React.ReactNode[] }) {
+  return (
+    <ul className="list-disc pl-5 space-y-1.5">
+      {items.map((item, i) => (
+        <li key={i}>{item}</li>
+      ))}
+    </ul>
+  );
+}
+
+export default function LegalPage({ title, intro, children }: Props) {
+  return (
+    <section className="bg-brand-paper dark:bg-brand-charcoal text-brand-charcoal dark:text-gray-200">
+      <div className="mx-auto max-w-3xl px-4 py-12 sm:py-16">
+        <h1 className="font-display text-2xl sm:text-3xl font-bold tracking-tight text-brand-charcoal dark:text-white">
+          {title}
+        </h1>
+        <p className="mt-3 text-gray-700 dark:text-gray-300 text-base">{intro}</p>
+        <p className="mt-2 text-xs text-gray-600 dark:text-gray-400">
+          Last updated: {ORGANISATION.policiesLastUpdated}
+        </p>
+
+        <div className="mt-8 glass-panel p-5 sm:p-6">{children}</div>
+
+        {/* Every policy page ends with a working way to reach a human — Razorpay
+            checks that contact details are present and consistent site-wide. */}
+        <div className="mt-6 glass-panel p-5 sm:p-6">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Contact us</h2>
+          <div className="mt-2 space-y-1 text-sm text-gray-700 dark:text-gray-300">
+            <p className="font-medium text-gray-900 dark:text-white">{ORGANISATION.legalName}</p>
+            <p>{ADDRESS_INLINE}</p>
+            <p>
+              Attn: {ORGANISATION.contactName} &middot;{" "}
+              <a
+                href={ORGANISATION.phoneHref}
+                className="text-lime-600 dark:text-lime-400 hover:underline"
+              >
+                {ORGANISATION.phone}
+              </a>
+            </p>
+            <p>
+              <a
+                href={`mailto:${ORGANISATION.email}`}
+                className="text-lime-600 dark:text-lime-400 hover:underline"
+              >
+                {ORGANISATION.email}
+              </a>
+            </p>
+          </div>
+          <p className="mt-3 text-xs text-gray-600 dark:text-gray-400">
+            We usually respond within 1–2 business days. See also our{" "}
+            <Link to="/contact" className="text-lime-600 dark:text-lime-400 hover:underline">
+              contact page
+            </Link>
+            .
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/pages/legal/Privacy.tsx
+++ b/src/pages/legal/Privacy.tsx
@@ -1,0 +1,156 @@
+import { Link } from "react-router-dom";
+import LegalPage, { List, Section } from "./LegalPage";
+import { ADDRESS_INLINE, ORGANISATION } from "../../constants/organisation";
+
+// Deliberately describes what this site actually does, field by field, rather
+// than generic boilerplate: the registration form's fields, Razorpay for
+// payments, Supabase for storage, and the specific browser storage keys used.
+
+export default function Privacy() {
+  return (
+    <LegalPage
+      title="Privacy Policy"
+      intro={`What ${ORGANISATION.legalName} collects when you register for an event, why, and what we do with it.`}
+    >
+      <Section heading="Who is responsible">
+        <p>
+          <strong>{ORGANISATION.legalName}</strong>, {ADDRESS_INLINE}, decides how and why the
+          information described here is used. Contact details are at the bottom of this page.
+        </p>
+      </Section>
+
+      <Section heading="What we collect">
+        <p>When an organisation registers, the form asks for:</p>
+        <List
+          items={[
+            <>
+              <strong>About the organisation</strong> — company name, contact person's name,
+              official email address, phone number, and optionally a personal email address and
+              the state you are registering from.
+            </>,
+            <>
+              <strong>About each player entered</strong> — name, phone number, official email
+              address, and optionally a personal email address and designation or employee id.
+            </>,
+            <>
+              <strong>About the entry</strong> — the categories chosen, team names, and the
+              amount payable.
+            </>,
+          ]}
+        />
+        <p>
+          If you enter other people as players, you confirm you are entitled to give us their
+          details for this purpose and that they know you have.
+        </p>
+      </Section>
+
+      <Section heading="Payment details — what we never see">
+        <p>
+          Payments are processed by <strong>Razorpay</strong>, a payment gateway regulated in
+          India. When you pay, you enter your card, UPI, netbanking or wallet details directly
+          into Razorpay's secure checkout.
+        </p>
+        <p>
+          <strong>
+            Those details never reach our servers and we never store them.
+          </strong>{" "}
+          What we receive back is limited to an order reference, a payment identifier, the
+          amount, and whether the payment succeeded. Razorpay handles your payment information
+          under its own privacy policy.
+        </p>
+      </Section>
+
+      <Section heading="Why we use it">
+        <List
+          items={[
+            "To process your registration, confirm your entry and take payment for it.",
+            "To produce and store your invoice, including any GST details required by law.",
+            "To contact you about the event you registered for — schedules, draws, venue changes and the Captains' Meeting.",
+            "To verify eligibility, resolve disputes and keep an accurate record of entries.",
+            "To meet accounting, tax and other legal obligations.",
+          ]}
+        />
+        <p>
+          We do not sell your information, and we do not use it for unrelated marketing.
+        </p>
+      </Section>
+
+      <Section heading="Where it is held">
+        <p>
+          Registration records and invoices are held in our Supabase project, hosted in India
+          (Mumbai region). Access is restricted to administrators of{" "}
+          {ORGANISATION.legalName} who need it to run events.
+        </p>
+      </Section>
+
+      <Section heading="Who else sees it">
+        <List
+          items={[
+            "Razorpay, to take payment and issue any refund.",
+            "Supabase, as the hosting provider that stores the records on our behalf.",
+            "Anyone we are legally required to disclose it to, such as a tax authority or a court.",
+          ]}
+        />
+        <p>
+          Names and team names of entered players appear in published draws, schedules and
+          results — that is inherent to running a tournament.
+        </p>
+      </Section>
+
+      <Section heading="How long we keep it">
+        <p>
+          Registration and invoice records are kept for as long as needed to run the event and
+          then for the period required by Indian tax and accounting rules. After that they are
+          deleted or anonymised.
+        </p>
+      </Section>
+
+      <Section heading="Storage in your browser">
+        <p>
+          This site does not use advertising or tracking cookies. It stores a small amount of
+          data in your own browser:
+        </p>
+        <List
+          items={[
+            "an in-progress registration draft, so a failed payment or a refresh does not lose what you typed;",
+            "your light or dark theme preference;",
+            "a payment result passed to the confirmation screen immediately after checkout;",
+            "for administrators only, a session that keeps you signed in.",
+          ]}
+        />
+        <p>Clearing your browser storage removes all of these.</p>
+      </Section>
+
+      <Section heading="Your choices">
+        <p>
+          Email{" "}
+          <a
+            href={`mailto:${ORGANISATION.email}`}
+            className="text-lime-600 dark:text-lime-400 hover:underline"
+          >
+            {ORGANISATION.email}
+          </a>{" "}
+          to ask for a copy of what we hold about you, to have something corrected, or to have
+          it deleted. Write from the official email address used to register, and quote your
+          order id or <code>MKB-</code> reference so we can find the record.
+        </p>
+        <p>
+          We may need to keep information required for tax or legal reasons even after a
+          deletion request, and we cannot remove a completed entry from the historical record
+          of an event that has already been played.
+        </p>
+      </Section>
+
+      <Section heading="Changes">
+        <p>
+          We may update this policy; the date it was last changed is shown at the top of this
+          page. See also our{" "}
+          <Link to="/terms" className="text-lime-600 dark:text-lime-400 hover:underline">
+            Terms &amp; Conditions
+          </Link>
+          .
+        </p>
+      </Section>
+    </LegalPage>
+  );
+}

--- a/src/pages/legal/Refunds.tsx
+++ b/src/pages/legal/Refunds.tsx
@@ -1,0 +1,98 @@
+import { Link } from "react-router-dom";
+import LegalPage, { List, Section } from "./LegalPage";
+import { ORGANISATION } from "../../constants/organisation";
+import { TOURNAMENT } from "../../constants/badminton";
+
+// Wording here must stay consistent with the acknowledgement registrants tick at
+// checkout (component/badminton/StepReview.tsx) — both say fees are strictly
+// non-refundable and entries non-transferable.
+
+export default function Refunds() {
+  return (
+    <LegalPage
+      title="Refund & Cancellation Policy"
+      intro={`How entry fees are treated once paid, for events organised by ${ORGANISATION.legalName}.`}
+    >
+      <Section heading="Entry fees are non-refundable">
+        <p>
+          Entry fees are <strong>strictly non-refundable</strong> once paid. Registration
+          confirms a place in the draw, and costs such as court hire, shuttles, officials and
+          prizes are committed well in advance on the basis of confirmed entries.
+        </p>
+        <p>
+          You are asked to confirm this before paying — the review step of the registration
+          form requires you to acknowledge it explicitly.
+        </p>
+      </Section>
+
+      <Section heading="Entries cannot be cancelled or transferred">
+        <List
+          items={[
+            "A confirmed entry cannot be cancelled for a refund.",
+            "An entry cannot be transferred to another organisation, another category, or a future edition of the tournament.",
+            "Replacing a named player within your own entry is permitted up to the Captains' Meeting, at no charge. This is a change of roster, not a transfer of entry.",
+          ]}
+        />
+      </Section>
+
+      <Section heading="When we do refund you">
+        <p>
+          If <strong>{ORGANISATION.legalName} cancels or abandons the event</strong> and it is
+          not played on either the scheduled dates ({TOURNAMENT.playingDates}) or the reserve
+          dates ({TOURNAMENT.reserveDates}), you receive a{" "}
+          <strong>full refund of your entry fee</strong>.
+        </p>
+        <p>
+          A change of venue, schedule, format or draw is not a cancellation, and does not
+          create a right to a refund. Nor does a walkover, a withdrawal, a no-show, or
+          disqualification for breach of the{" "}
+          <Link to="/terms" className="text-lime-600 dark:text-lime-400 hover:underline">
+            tournament terms
+          </Link>
+          .
+        </p>
+        <p>
+          If a refund is due for any other reason, it is at our discretion and we will tell you
+          in writing.
+        </p>
+      </Section>
+
+      <Section heading="How a refund reaches you">
+        <List
+          items={[
+            "Refunds are issued to the original payment method through Razorpay, our payment gateway. We cannot redirect a refund to a different card, account or UPI ID.",
+            "We initiate the refund within 5–7 working days of confirming it.",
+            "Once initiated, your bank or card issuer typically takes a further 5–10 working days to credit it. That leg is outside our control.",
+            "Refunds are made in Indian Rupees for the amount paid. Any bank charges or exchange differences on your side are not reimbursed.",
+          ]}
+        />
+      </Section>
+
+      <Section heading="Payments taken offline">
+        <p>
+          Where an organisation pays by bank transfer or UPI rather than through the online
+          checkout, the same policy applies from the point the payment reaches us and the
+          registration is confirmed against its <code>MKB-</code> reference code.
+        </p>
+      </Section>
+
+      <Section heading="Raising a refund query">
+        <p>
+          Email{" "}
+          <a
+            href={`mailto:${ORGANISATION.email}`}
+            className="text-lime-600 dark:text-lime-400 hover:underline"
+          >
+            {ORGANISATION.email}
+          </a>{" "}
+          from the official email address used to register, quoting your{" "}
+          <strong>order id or {`MKB-`} reference code</strong> and the registered organisation
+          name. Both appear on your confirmation screen and on your invoice.
+        </p>
+        <p>
+          We aim to acknowledge within 1–2 business days and to resolve within 7 working days.
+        </p>
+      </Section>
+    </LegalPage>
+  );
+}

--- a/src/pages/legal/ServiceDelivery.tsx
+++ b/src/pages/legal/ServiceDelivery.tsx
@@ -1,0 +1,117 @@
+import { Link } from "react-router-dom";
+import LegalPage, { List, Section } from "./LegalPage";
+import { ORGANISATION } from "../../constants/organisation";
+import { TOURNAMENT } from "../../constants/badminton";
+
+// Razorpay's merchant checklist asks for a "Shipping & Delivery Policy" even
+// for service businesses, so the page keeps that title. The content is honest
+// that nothing is physically shipped and describes what is actually delivered.
+
+export default function ServiceDelivery() {
+  return (
+    <LegalPage
+      title="Shipping & Delivery Policy"
+      intro={`${ORGANISATION.legalName} sells event registrations, not physical goods. This page explains what you receive when you pay, and when.`}
+    >
+      <Section heading="Nothing is shipped">
+        <p>
+          We do not sell or dispatch any physical product, and no shipping charges are ever
+          applied. What you buy is a <strong>place in a tournament</strong>, delivered
+          electronically and fulfilled by our running the event.
+        </p>
+      </Section>
+
+      <Section heading="What you receive, and when">
+        <List
+          items={[
+            <>
+              <strong>Immediately on successful payment</strong> — an on-screen confirmation
+              showing your order reference, the categories entered and the amount paid.
+            </>,
+            <>
+              <strong>Within a few moments</strong> — a GST-compliant invoice, downloadable
+              from the confirmation screen. If it is still generating, the page will keep
+              checking; you can also retrieve it later from the registration status page.
+            </>,
+            <>
+              <strong>Before the Captains' Meeting</strong> — the draw, match schedule and
+              venue details, sent to the contact person's email address.
+            </>,
+            <>
+              <strong>On the playing dates</strong> — the event itself.
+            </>,
+          ]}
+        />
+      </Section>
+
+      <Section heading="Registrations paid offline">
+        <p>
+          If your organisation chooses to pay by bank transfer or UPI instead of the online
+          checkout, you receive an <code>MKB-</code> reference code straight away and your
+          place is held as pending. Delivery is confirmed once we have matched the payment,
+          normally within 1–2 business days of it reaching us. Quote the reference code with
+          your transfer so we can match it.
+        </p>
+      </Section>
+
+      <Section heading="Where and when the event takes place">
+        <List
+          items={[
+            <>
+              <strong>Event</strong> — {TOURNAMENT.title} ({TOURNAMENT.edition})
+            </>,
+            <>
+              <strong>Venue</strong> — {TOURNAMENT.venue}
+            </>,
+            <>
+              <strong>Playing dates</strong> — {TOURNAMENT.playingDates}
+            </>,
+            <>
+              <strong>Reserve dates</strong> — {TOURNAMENT.reserveDates}
+            </>,
+            <>
+              <strong>Registrations close</strong> — {TOURNAMENT.lastRegistration}
+            </>,
+          ]}
+        />
+        <p>
+          Schedules and venues can change; we notify the registered contact person when they
+          do. See the{" "}
+          <Link to="/terms" className="text-lime-600 dark:text-lime-400 hover:underline">
+            Terms &amp; Conditions
+          </Link>
+          .
+        </p>
+      </Section>
+
+      <Section heading="If your confirmation does not arrive">
+        <p>
+          If payment left your account but you did not see a confirmation, do not pay again.
+          Check the{" "}
+          <Link
+            to="/registration/status"
+            className="text-lime-600 dark:text-lime-400 hover:underline"
+          >
+            registration status page
+          </Link>{" "}
+          first, then email{" "}
+          <a
+            href={`mailto:${ORGANISATION.email}`}
+            className="text-lime-600 dark:text-lime-400 hover:underline"
+          >
+            {ORGANISATION.email}
+          </a>{" "}
+          with your order id or reference code. We will confirm the position within 1–2
+          business days.
+        </p>
+        <p>
+          Refunds are governed by the{" "}
+          <Link to="/refunds" className="text-lime-600 dark:text-lime-400 hover:underline">
+            Refund &amp; Cancellation Policy
+          </Link>
+          .
+        </p>
+      </Section>
+    </LegalPage>
+  );
+}

--- a/src/pages/legal/Terms.tsx
+++ b/src/pages/legal/Terms.tsx
@@ -1,0 +1,140 @@
+import { Link } from "react-router-dom";
+import LegalPage, { List, Section } from "./LegalPage";
+import { ADDRESS_INLINE, ORGANISATION } from "../../constants/organisation";
+import { BADMINTON_CATEGORIES, formatINR, TOURNAMENT } from "../../constants/badminton";
+
+export default function Terms() {
+  return (
+    <LegalPage
+      title="Terms & Conditions"
+      intro={`The terms on which ${ORGANISATION.legalName} accepts registrations and runs its events.`}
+    >
+      <Section heading="Who you are contracting with">
+        <p>
+          This site is operated by <strong>{ORGANISATION.legalName}</strong>, {ADDRESS_INLINE}.
+          Registering for an event, or using this site, means you accept these terms on behalf
+          of the organisation you are registering.
+        </p>
+      </Section>
+
+      <Section heading="Who can enter">
+        <List
+          items={[
+            "Events are for corporate and institutional teams. Each entry is made by an organisation, not by an individual.",
+            "Players entered under an organisation must be genuinely associated with it. We may ask for proof of employment or association at any point.",
+            "The person registering confirms they are authorised to commit their organisation and to share the contact details of the players they enter.",
+          ]}
+        />
+      </Section>
+
+      <Section heading="Entry fees and confirmation">
+        <p>
+          Fees are quoted and charged in Indian Rupees, and are shown in full on the{" "}
+          <Link to="/badminton" className="text-lime-600 dark:text-lime-400 hover:underline">
+            registration page
+          </Link>{" "}
+          before you pay. For {TOURNAMENT.title} they are:
+        </p>
+        <List
+          items={BADMINTON_CATEGORIES.map((c) => (
+            <>
+              {c.label} — <strong>{formatINR(c.fee)}</strong> {c.unit}
+            </>
+          ))}
+        />
+        <p>
+          The amount payable is always calculated on our servers from the categories you
+          select. A registration is <strong>confirmed only once the fee has been received</strong>;
+          submitting the form alone does not reserve a place. Registrations close on{" "}
+          {TOURNAMENT.lastRegistration}.
+        </p>
+        <p>
+          Entry fees are non-refundable. See the{" "}
+          <Link to="/refunds" className="text-lime-600 dark:text-lime-400 hover:underline">
+            Refund &amp; Cancellation Policy
+          </Link>
+          .
+        </p>
+      </Section>
+
+      <Section heading="Running the event">
+        <p>
+          {TOURNAMENT.title} is scheduled for {TOURNAMENT.playingDates} at {TOURNAMENT.venue},
+          with {TOURNAMENT.reserveDates} held in reserve. We may:
+        </p>
+        <List
+          items={[
+            "set and change the format, draw, seeding and match schedule;",
+            "move matches between the scheduled and reserve dates, or between courts and venues, including at short notice;",
+            "appoint officials whose decisions on play are final;",
+            "reject or disqualify an entry, without refund, where information given is false, a player is ineligible, or conduct falls below the standard below.",
+          ]}
+        />
+        <p>
+          Where we change something material, we will tell the registered contact person using
+          the details supplied at registration.
+        </p>
+      </Section>
+
+      <Section heading="Conduct">
+        <p>
+          Players and supporters are expected to compete fairly, follow the laws of the game,
+          respect officials and other participants, and comply with venue rules. Abusive
+          behaviour, intimidation, or any attempt to manipulate a result may lead to
+          disqualification without refund.
+        </p>
+      </Section>
+
+      <Section heading="Participation is at your own risk">
+        <p>
+          Sport carries a risk of injury. Each participant takes part at their own risk and
+          confirms they are medically fit to do so. {ORGANISATION.legalName} is not liable for
+          injury, illness, or loss of or damage to personal property at a venue, except where
+          such liability cannot be excluded by law.
+        </p>
+        <p>
+          Where our liability cannot be excluded, it is limited to the entry fee paid for the
+          affected entry. We are not liable for indirect or consequential loss, including
+          travel or accommodation costs booked around an event.
+        </p>
+      </Section>
+
+      <Section heading="Photography and media">
+        <p>
+          We may photograph or film events and use the material to report on and promote our
+          events. If you would prefer a specific individual not to appear, email us and we will
+          make reasonable efforts to accommodate that.
+        </p>
+      </Section>
+
+      <Section heading="Your information">
+        <p>
+          What we collect and why is set out in the{" "}
+          <Link to="/privacy" className="text-lime-600 dark:text-lime-400 hover:underline">
+            Privacy Policy
+          </Link>
+          . How your entry is delivered to you is set out in the{" "}
+          <Link to="/shipping" className="text-lime-600 dark:text-lime-400 hover:underline">
+            Shipping &amp; Delivery Policy
+          </Link>
+          .
+        </p>
+      </Section>
+
+      <Section heading="Changes to these terms">
+        <p>
+          We may update these terms. The version in force for your entry is the one published
+          when you registered, and the date it was last changed is shown at the top of this
+          page.
+        </p>
+      </Section>
+
+      <Section heading="Governing law">
+        <p>
+          These terms are governed by the laws of India. The courts at Pune, Maharashtra have
+          exclusive jurisdiction over any dispute arising from them.
+        </p>
+      </Section>
+    </LegalPage>
+  );
+}

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -25,6 +25,10 @@ import TournamentAdmin from "../pages/TournamentAdmin";
 import RegistrationsDashboard from "../pages/RegistrationsDashboard";
 import InvoiceSettings from "../pages/InvoiceSettings";
 import RegistrationStatus from "../pages/RegistrationStatus";
+import Terms from "../pages/legal/Terms";
+import Privacy from "../pages/legal/Privacy";
+import Refunds from "../pages/legal/Refunds";
+import ServiceDelivery from "../pages/legal/ServiceDelivery";
 import PageTransition from "../component/PageTransition";
 import TopProgressBar from "../component/TopProgressBar";
 
@@ -44,6 +48,12 @@ const AnimatedRoutes: React.FC = () => {
         <Route path="tournaments" element={<PageTransition><TournamentsPage /></PageTransition>} />
         <Route path="badminton" element={<PageTransition><BadmintonRegister /></PageTransition>} />
         <Route path="registration/status" element={<PageTransition><RegistrationStatus /></PageTransition>} />
+        {/* Policy pages. Public and linked from the footer on every page —
+            Razorpay's merchant verification checks all four are reachable. */}
+        <Route path="terms" element={<PageTransition><Terms /></PageTransition>} />
+        <Route path="privacy" element={<PageTransition><Privacy /></PageTransition>} />
+        <Route path="refunds" element={<PageTransition><Refunds /></PageTransition>} />
+        <Route path="shipping" element={<PageTransition><ServiceDelivery /></PageTransition>} />
         <Route element={<PrivateRoute />}>
           <Route path="menu" element={<PageTransition><Menu /></PageTransition>} />
           <Route path="/menu/content-management" element={<PageTransition><HomepageManagement /></PageTransition>} />


### PR DESCRIPTION
Razorpay is verifying maharashtrakrida.in for live-mode activation. Their review checks a
fixed set of pages, and four did not exist. Until they're live, activation stays blocked —
which is what's holding up the account switch, since live keys can't be generated for an
unactivated account.

## What was missing

| Requirement | Before | Now |
| --- | --- | --- |
| About Us | ✅ `/about` | unchanged |
| Contact Us | ✅ `/contact` | now single-sourced |
| Pricing shown | ✅ `/badminton` | unchanged |
| Terms & Conditions | ❌ | ✅ `/terms` |
| Privacy Policy | ❌ | ✅ `/privacy` |
| Refund & Cancellation | ❌ | ✅ `/refunds` |
| Shipping & Delivery | ❌ | ✅ `/shipping` |
| Policy links site-wide | ❌ | ✅ footer "Legal" column |

## The contradiction that would have failed review

The footer advertised **+91 99999 99999** and `hello@maharashtrakrida.in`, while `/contact`
gave the real number and address. A placeholder phone on a site under merchant review is
exactly what gets an application sent back.

The cause was the same facts hardcoded in three files, so `src/constants/organisation.ts` is
now the single source and the footer and contact page read from it. The drift is fixed by
construction, not by editing two strings. `grep` for the placeholders now returns nothing.

## The policy text

Written for what this site actually does, not boilerplate:

- **Privacy** names the exact fields the registration form collects, states that Razorpay
  handles payment and card/UPI details never reach our servers, and lists the browser storage
  actually used (registration draft, theme, admin session) — no cookie-banner theatre for
  cookies we don't set.
- **Shipping & Delivery** keeps the title Razorpay's checklist looks for while being honest
  that nothing is shipped: what's sold is a place in a tournament, delivered electronically
  on payment with the invoice available immediately.
- **Refunds**: non-refundable once paid, full refund only where we cancel or abandon the
  event, refunds to the original method via Razorpay with realistic timelines.
- **Terms**: eligibility, server-side fee calculation, organiser's rights over schedule and
  draw, participation at own risk, Pune jurisdiction.

Fees, dates and venue are read from the existing constants, so the recent ₹2,000/₹4,000
change can't leave a stale figure behind in a legal page.

## Consistency with checkout

Reviewers compare checkout copy against the policy page. `StepReview` has always made
registrants tick a box saying fees are "strictly non-refundable" and non-transferable — the
refund policy now says the same thing in the same words, and the checkbox links to all three
policies rather than agreeing by coincidence.

## Also

The footer's Instagram and Twitter icons pointed at bare `instagram.com` and `twitter.com`.
Removed rather than shipped into a review as dead links — add them back with real handles.

## Verification

`npm run lint`, `npm run typecheck`, `npm run build` all clean; `npm test` unaffected at 71
passing (nothing under `supabase/functions/` changed). All four routes confirmed registered
and their content present in the production bundle.

**Frontend only — no `supabase functions deploy` needed.**

After merge, load the four pages on the live domain before asking Razorpay to re-check, then
submit: `/terms`, `/privacy`, `/refunds`, `/shipping`, `/contact`, `/about`.
