### PR TITLE
feat: Add a server-enforced kill switch for online payments

### DIFF
--- a/src/component/badminton/StepPayment.tsx
+++ b/src/component/badminton/StepPayment.tsx
@@ -17,19 +17,35 @@ export default function StepPayment() {
   const ready = useRazorpayScript();
   const [loading, setLoading] = useState(false);
   const [method, setMethod] = useState<Method>("online");
+  const [onlineEnabled, setOnlineEnabled] = useState(true);
   const [offlineEnabled, setOfflineEnabled] = useState(false);
+  const [settingsLoaded, setSettingsLoaded] = useState(false);
 
   const org = state.organization;
   const totalPaise = state.entries.reduce((sum, e) => sum + CATEGORY_BY_CODE[e.category].fee, 0);
 
   useEffect(() => {
     getPaymentSettings()
-      .then((s) => setOfflineEnabled(!!s.offline_enabled))
-      .catch(() => setOfflineEnabled(false));
+      .then((s) => {
+        setOnlineEnabled(s.online_enabled !== false);
+        setOfflineEnabled(!!s.offline_enabled);
+        // Don't strand someone on a method that's been switched off.
+        if (s.online_enabled === false && s.offline_enabled) setMethod("offline");
+      })
+      .catch(() => {
+        // Can't read the switches: keep the pre-existing posture rather than
+        // blocking registration. The Edge Function is the real gate and will
+        // refuse a suspended method regardless of what the form shows.
+        setOnlineEnabled(true);
+        setOfflineEnabled(false);
+      })
+      .finally(() => setSettingsLoaded(true));
   }, []);
 
+  const nothingAvailable = settingsLoaded && !onlineEnabled && !offlineEnabled;
+
   const pay = async () => {
-    if (!ready || loading) return;
+    if (!ready || loading || !onlineEnabled) return;
     if (!org || state.entries.length === 0) {
       showToast("Registration details are incomplete.", "error");
       return;
@@ -156,7 +172,19 @@ export default function StepPayment() {
         Total payable: <span className="font-semibold text-gray-900 dark:text-white">{formatINR(totalPaise)}</span>
       </p>
 
-      {offlineEnabled ? (
+      {nothingAvailable && (
+        <div className="rounded-xl border border-amber-500/30 bg-amber-500/10 p-4">
+          <p className="text-sm font-semibold text-amber-800 dark:text-amber-200">
+            Registration is temporarily paused
+          </p>
+          <p className="mt-1 text-xs text-amber-700 dark:text-amber-300">
+            We can't accept payments right now. Your entries are saved on this device — please try
+            again shortly, or contact {TOURNAMENT.contactName} on {TOURNAMENT.contactPhone}.
+          </p>
+        </div>
+      )}
+
+      {onlineEnabled && offlineEnabled && (
         <div className="flex flex-col sm:flex-row gap-3">
           <button type="button" onClick={() => setMethod("online")} className={optionCls(method === "online")}>
             <p className="font-semibold text-gray-900 dark:text-white">Pay now online</p>
@@ -172,16 +200,29 @@ export default function StepPayment() {
             </p>
           </button>
         </div>
-      ) : (
+      )}
+
+      {onlineEnabled && !offlineEnabled && (
         <p className="text-sm text-gray-600 dark:text-gray-300">
           You'll be redirected to the secure Razorpay checkout to complete the payment.
         </p>
       )}
 
-      {method === "online" ? (
+      {!onlineEnabled && offlineEnabled && (
+        <div className="rounded-xl border border-black/10 dark:border-white/10 p-4">
+          <p className="font-semibold text-gray-900 dark:text-white">Company will pay separately</p>
+          <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+            Online card payment is unavailable at the moment, so reserve your place now and settle by
+            bank transfer. You'll get a reference code immediately and we'll confirm once payment is
+            received.
+          </p>
+        </div>
+      )}
+
+      {nothingAvailable ? null : method === "online" ? (
         <button
           onClick={pay}
-          disabled={!ready || loading}
+          disabled={!ready || loading || !onlineEnabled}
           className="glass-button-primary inline-flex items-center justify-center gap-2 w-full sm:w-auto px-6 py-2.5 disabled:opacity-50 disabled:cursor-not-allowed"
         >
           {loading && <TailSpin color="#ffffff" height={18} width={18} />}

--- a/src/pages/InvoiceSettings.tsx
+++ b/src/pages/InvoiceSettings.tsx
@@ -202,25 +202,56 @@ export default function InvoiceSettings() {
         </div>
       </form>
 
-      {/* Offline payment settings */}
+      {/* Payment methods */}
       <h2 className="font-display text-xl font-bold text-gray-900 dark:text-white mt-10 mb-2">
-        Offline Payment (&quot;company will pay separately&quot;)
+        Payment Methods
       </h2>
       <p className="text-sm text-gray-600 dark:text-gray-300 mb-4">
-        When enabled, registrants can reserve without paying online and settle by bank transfer. These
-        details are shown on their status page so they know where to send the money.
+        Which ways registrants can pay. Both switches are enforced on the server, so turning one off
+        genuinely stops that method rather than only hiding it on the form.
       </p>
 
       <form onSubmit={onSavePay} className="glass-panel p-5 sm:p-6 space-y-5">
-        <label className="flex items-center gap-3 cursor-pointer">
+        <label className="flex items-start gap-3 cursor-pointer">
           <input
             type="checkbox"
-            className="w-4 h-4"
+            className="w-4 h-4 mt-0.5"
+            checked={pay.online_enabled}
+            onChange={(e) => setP("online_enabled", e.target.checked)}
+          />
+          <span>
+            <span className="block text-sm font-semibold text-gray-900 dark:text-white">
+              Online payment — card, UPI, netbanking via Razorpay
+            </span>
+            <span className="block text-xs text-gray-600 dark:text-gray-400 mt-0.5">
+              Turn off to suspend card payments, for example while Razorpay is verifying the website
+              or during a gateway outage. Leave offline enabled below so teams can still register.
+            </span>
+          </span>
+        </label>
+
+        {!pay.online_enabled && !pay.offline_enabled && (
+          <p className="rounded-lg bg-amber-500/10 border border-amber-500/30 px-3 py-2 text-xs text-amber-700 dark:text-amber-300">
+            Both methods are off — nobody can complete a registration. Enable at least one.
+          </p>
+        )}
+
+        <label className="flex items-start gap-3 cursor-pointer pt-1">
+          <input
+            type="checkbox"
+            className="w-4 h-4 mt-0.5"
             checked={pay.offline_enabled}
             onChange={(e) => setP("offline_enabled", e.target.checked)}
           />
-          <span className="text-sm font-semibold text-gray-900 dark:text-white">
-            Offer &quot;company will pay separately&quot; on the registration form
+          <span>
+            <span className="block text-sm font-semibold text-gray-900 dark:text-white">
+              Offer &quot;company will pay separately&quot; on the registration form
+            </span>
+            <span className="block text-xs text-gray-600 dark:text-gray-400 mt-0.5">
+              Registrants reserve a place, get an MKB- reference code, and settle by bank transfer.
+              The details below appear on their status page. Confirm each one from the registrations
+              dashboard once the money arrives.
+            </span>
           </span>
         </label>
 

--- a/src/services/paymentSettingsService.ts
+++ b/src/services/paymentSettingsService.ts
@@ -4,6 +4,9 @@ import { toServiceError } from "./error";
 const TABLE = "payment_settings";
 
 export type PaymentSettings = {
+  /** Razorpay checkout. Turn off to suspend card payments — the Edge Function
+   *  enforces this too, so it is a real switch and not just a hidden button. */
+  online_enabled: boolean;
   offline_enabled: boolean;
   bank_account_name: string | null;
   bank_account_number: string | null;
@@ -13,6 +16,7 @@ export type PaymentSettings = {
 };
 
 export const DEFAULT_PAYMENT_SETTINGS: PaymentSettings = {
+  online_enabled: true,
   offline_enabled: false,
   bank_account_name: null,
   bank_account_number: null,

--- a/supabase/functions/_shared/registration.ts
+++ b/supabase/functions/_shared/registration.ts
@@ -141,6 +141,41 @@ const SB = () => ({
   key: Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
 });
 
+/** Which payment methods the organiser currently accepts. */
+export type PaymentModes = { onlineEnabled: boolean; offlineEnabled: boolean };
+
+/** Pure, so the fallback posture is testable without a network. */
+export function toPaymentModes(row: Record<string, unknown> | null): PaymentModes {
+  // No settings row has ever been saved: fall back to the column defaults —
+  // online on, offline off — which is how this behaved before the switch existed.
+  if (!row) return { onlineEnabled: true, offlineEnabled: false };
+  return {
+    onlineEnabled: row.online_enabled !== false,
+    offlineEnabled: row.offline_enabled === true,
+  };
+}
+
+/**
+ * Reads the payment switches with the service role.
+ *
+ * Deliberately NOT fail-open. If this lookup fails we cannot know whether
+ * online payments are meant to be suspended, and the whole point of the switch
+ * is being certain they are off during gateway verification — so the caller
+ * refuses the order. The cost of that is near zero in practice: this reads the
+ * same database the registration row is about to be written to, so if it is
+ * unreachable the request was going to fail anyway.
+ */
+export async function fetchPaymentModes(): Promise<PaymentModes> {
+  const { url, key } = SB();
+  const res = await fetch(
+    `${url}/rest/v1/payment_settings?select=online_enabled,offline_enabled&limit=1`,
+    { headers: { apikey: key, Authorization: `Bearer ${key}` } }
+  );
+  if (!res.ok) throw new Error(`payment_settings lookup failed (${res.status})`);
+  const rows = await res.json();
+  return toPaymentModes(Array.isArray(rows) && rows[0] ? rows[0] : null);
+}
+
 /** Inserts a PENDING registration row (service role). `paymentMethod` is
  * "razorpay" for online orders or "offline" for the reserve-and-pay-later
  * flow; `orderId` is the Razorpay order id or the generated MKB- code. */

--- a/supabase/functions/create-badminton-order/index.test.ts
+++ b/supabase/functions/create-badminton-order/index.test.ts
@@ -29,8 +29,17 @@ function post(body: unknown, origin: string = ORIGIN): Request {
 const RAZORPAY_OK = { match: "api.razorpay.com", json: { id: "order_TESTORDER1" } };
 const SUPABASE_OK = { match: "stub.supabase.co", status: 201, text: "" };
 
+// The handler reads payment_settings before doing anything, so this route has
+// to come first (stubFetch takes the first match). Both methods on unless a test
+// says otherwise.
+const settings = (online: boolean, offline: boolean) => ({
+  match: "payment_settings",
+  json: [{ online_enabled: online, offline_enabled: offline }],
+});
+const BOTH_ON = settings(true, true);
+
 Deno.test("online path: charges the server-computed amount and stores the roster", async () => {
-  const fetchStub = stubFetch([RAZORPAY_OK, SUPABASE_OK]);
+  const fetchStub = stubFetch([BOTH_ON, RAZORPAY_OK, SUPABASE_OK]);
   try {
     const res = await handleRequest(
       post({
@@ -72,7 +81,7 @@ Deno.test("online path: charges the server-computed amount and stores the roster
 
 // The whole point of computeAmount living on the server.
 Deno.test("a client-supplied amount cannot lower the charge", async () => {
-  const fetchStub = stubFetch([RAZORPAY_OK, SUPABASE_OK]);
+  const fetchStub = stubFetch([BOTH_ON, RAZORPAY_OK, SUPABASE_OK]);
   try {
     const res = await handleRequest(
       post({
@@ -92,7 +101,7 @@ Deno.test("a client-supplied amount cannot lower the charge", async () => {
 });
 
 Deno.test("offline path: reserves a code and never calls Razorpay", async () => {
-  const fetchStub = stubFetch([RAZORPAY_OK, SUPABASE_OK]);
+  const fetchStub = stubFetch([BOTH_ON, RAZORPAY_OK, SUPABASE_OK]);
   try {
     const res = await handleRequest(
       post({
@@ -118,7 +127,7 @@ Deno.test("offline path: reserves a code and never calls Razorpay", async () => 
 });
 
 Deno.test("validator failures are 400s carrying the message, and touch nothing", async () => {
-  const fetchStub = stubFetch([RAZORPAY_OK, SUPABASE_OK]);
+  const fetchStub = stubFetch([BOTH_ON, RAZORPAY_OK, SUPABASE_OK]);
   try {
     const res = await handleRequest(
       post({ organization, entries: [{ category: "mens_doubles", players: [player] }] })
@@ -134,7 +143,7 @@ Deno.test("validator failures are 400s carrying the message, and touch nothing",
 // Regression for the inherited-key hole: this used to pass the category check
 // and then crash the PLAYER_BOUNDS destructure, i.e. a 500 on crafted input.
 Deno.test("a prototype-key category is a 400, not a 500", async () => {
-  const fetchStub = stubFetch([RAZORPAY_OK, SUPABASE_OK]);
+  const fetchStub = stubFetch([BOTH_ON, RAZORPAY_OK, SUPABASE_OK]);
   try {
     for (const category of ["toString", "constructor"]) {
       const res = await handleRequest(post({ organization, entries: [{ category, players: [] }] }));
@@ -148,7 +157,7 @@ Deno.test("a prototype-key category is a 400, not a 500", async () => {
 });
 
 Deno.test("a disallowed origin is refused before any work happens", async () => {
-  const fetchStub = stubFetch([RAZORPAY_OK, SUPABASE_OK]);
+  const fetchStub = stubFetch([BOTH_ON, RAZORPAY_OK, SUPABASE_OK]);
   try {
     const res = await handleRequest(
       post({ organization, entries: [{ category: "mens_singles", players: [player] }] },
@@ -163,6 +172,7 @@ Deno.test("a disallowed origin is refused before any work happens", async () => 
 
 Deno.test("a Razorpay outage is a 500, and no PENDING row is written", async () => {
   const fetchStub = stubFetch([
+    BOTH_ON,
     { match: "api.razorpay.com", status: 502, text: "upstream boom" },
     SUPABASE_OK,
   ]);
@@ -181,6 +191,7 @@ Deno.test("a Razorpay outage is a 500, and no PENDING row is written", async () 
 // so a database hiccup must not cost the user their payment.
 Deno.test("a failed PENDING insert still returns the order", async () => {
   const fetchStub = stubFetch([
+    BOTH_ON,
     RAZORPAY_OK,
     { match: "stub.supabase.co", status: 500, text: "db down" },
   ]);
@@ -190,6 +201,127 @@ Deno.test("a failed PENDING insert still returns the order", async () => {
     );
     assertEquals(res.status, 200);
     assertEquals((await res.json()).orderId, "order_TESTORDER1");
+  } finally {
+    fetchStub.restore();
+  }
+});
+
+// ── The payment kill switches ──────────────────────────────────────────────
+//
+// These matter more than they look. The switches also exist in the admin UI and
+// on the form, but this function runs with verify_jwt = false behind an origin
+// allowlist that admits non-browser callers — so the server check is the only
+// one that actually stops a determined caller. If these tests pass, "payments
+// are off" is a true statement rather than a hidden button.
+
+Deno.test("online off: a card payment is refused and no Razorpay order is created", async () => {
+  const fetchStub = stubFetch([settings(false, true), RAZORPAY_OK, SUPABASE_OK]);
+  try {
+    const res = await handleRequest(
+      post({ organization, entries: [{ category: "mens_singles", players: [player] }] })
+    );
+    assertEquals(res.status, 503);
+    assert((await res.json()).error.includes("Online payment is temporarily unavailable"));
+    assertEquals(fetchStub.to("api.razorpay.com").length, 0);
+    assertEquals(fetchStub.to("badminton_registrations").length, 0);
+  } finally {
+    fetchStub.restore();
+  }
+});
+
+Deno.test("online off: offline registration still works", async () => {
+  const fetchStub = stubFetch([settings(false, true), RAZORPAY_OK, SUPABASE_OK]);
+  try {
+    const res = await handleRequest(
+      post({
+        organization,
+        entries: [{ category: "mens_singles", players: [player] }],
+        paymentMode: "offline",
+      })
+    );
+    assertEquals(res.status, 200);
+    assertEquals((await res.json()).offline, true);
+    assertEquals(fetchStub.to("api.razorpay.com").length, 0);
+  } finally {
+    fetchStub.restore();
+  }
+});
+
+Deno.test("offline off: a reservation is refused", async () => {
+  const fetchStub = stubFetch([settings(true, false), RAZORPAY_OK, SUPABASE_OK]);
+  try {
+    const res = await handleRequest(
+      post({
+        organization,
+        entries: [{ category: "mens_singles", players: [player] }],
+        paymentMode: "offline",
+      })
+    );
+    assertEquals(res.status, 503);
+    assertEquals(fetchStub.to("badminton_registrations").length, 0);
+  } finally {
+    fetchStub.restore();
+  }
+});
+
+Deno.test("both off: nothing can be registered by any route", async () => {
+  const fetchStub = stubFetch([settings(false, false), RAZORPAY_OK, SUPABASE_OK]);
+  try {
+    for (const paymentMode of [undefined, "offline"]) {
+      const res = await handleRequest(
+        post({ organization, entries: [{ category: "mens_singles", players: [player] }], paymentMode })
+      );
+      assertEquals(res.status, 503);
+    }
+    assertEquals(fetchStub.to("api.razorpay.com").length, 0);
+    assertEquals(fetchStub.to("badminton_registrations").length, 0);
+  } finally {
+    fetchStub.restore();
+  }
+});
+
+// Fail closed, deliberately: if we can't read the switches we can't know that
+// online payments are meant to be suspended, and being certain of that is the
+// entire point of having them.
+Deno.test("an unreadable settings row refuses rather than assuming payments are on", async () => {
+  const fetchStub = stubFetch([
+    { match: "payment_settings", status: 500, text: "boom" },
+    RAZORPAY_OK,
+    SUPABASE_OK,
+  ]);
+  try {
+    const res = await handleRequest(
+      post({ organization, entries: [{ category: "mens_singles", players: [player] }] })
+    );
+    assertEquals(res.status, 500);
+    assertEquals(fetchStub.to("api.razorpay.com").length, 0);
+  } finally {
+    fetchStub.restore();
+  }
+});
+
+// A project that has never saved settings behaves as it did before the switch
+// existed: online on, offline off — matching the column defaults.
+Deno.test("no settings row at all keeps the pre-existing posture", async () => {
+  const fetchStub = stubFetch([
+    { match: "payment_settings", json: [] },
+    RAZORPAY_OK,
+    SUPABASE_OK,
+  ]);
+  try {
+    const online = await handleRequest(
+      post({ organization, entries: [{ category: "mens_singles", players: [player] }] })
+    );
+    assertEquals(online.status, 200);
+
+    const offline = await handleRequest(
+      post({
+        organization,
+        entries: [{ category: "mens_singles", players: [player] }],
+        paymentMode: "offline",
+      })
+    );
+    assertEquals(offline.status, 503);
   } finally {
     fetchStub.restore();
   }

--- a/supabase/functions/create-badminton-order/index.ts
+++ b/supabase/functions/create-badminton-order/index.ts
@@ -2,6 +2,7 @@ import { corsHeaders, isAllowedOrigin } from "../_shared/cors.ts";
 import { CategoryEntry, Organization } from "../_shared/badminton.ts";
 import {
   computeAmount,
+  fetchPaymentModes,
   generateReferenceCode,
   insertPendingRow,
   MAX_BODY_BYTES,
@@ -86,6 +87,29 @@ export async function handleRequest(req: Request): Promise<Response> {
       return new Response(JSON.stringify({ error: parsed.error }), { status: 400, headers });
     }
     const { organization, entries, paymentMode } = parsed;
+
+    // The organiser can suspend either payment method from the admin UI. This
+    // has to be enforced here, not just in the form: this function runs with
+    // verify_jwt = false behind an origin allowlist that admits non-browser
+    // callers, so a hidden button stops nobody. 503 rather than 400 — the
+    // request is fine, the method is just unavailable right now.
+    const modes = await fetchPaymentModes();
+    const wantsOffline = paymentMode === "offline";
+    if (wantsOffline && !modes.offlineEnabled) {
+      return new Response(
+        JSON.stringify({ error: "Offline registration is not available at the moment." }),
+        { status: 503, headers }
+      );
+    }
+    if (!wantsOffline && !modes.onlineEnabled) {
+      return new Response(
+        JSON.stringify({
+          error:
+            "Online payment is temporarily unavailable. Please try again later or contact us to register.",
+        }),
+        { status: 503, headers }
+      );
+    }
 
     // Server is the source of truth for the amount.
     const amount = computeAmount(entries);

--- a/supabase/migrations/20260729061500_online_payment_toggle.sql
+++ b/supabase/migrations/20260729061500_online_payment_toggle.sql
@@ -1,0 +1,24 @@
+-- A kill switch for online (Razorpay) payments.
+--
+-- Needed immediately because Razorpay is verifying the website for live-mode
+-- activation and online payments must stay off until that completes. Putting it
+-- in the database rather than in code means re-enabling afterwards is one click
+-- in /menu/invoice-settings — no PR, no Netlify build, no functions deploy.
+--
+-- Defaults to true so applying this migration changes nothing on its own; the
+-- switch is then thrown from the admin UI.
+--
+-- Note this table is publicly readable by design (see the payment_settings
+-- migration): the registration form has to know which methods to offer before
+-- anyone signs in. Only admins can write it, and — as of this change — the
+-- create-badminton-order Edge Function reads it server-side and refuses a
+-- disabled method, so turning the switch off actually stops orders rather than
+-- just hiding a button.
+
+alter table payment_settings
+  add column if not exists online_enabled boolean not null default true;
+
+comment on column payment_settings.online_enabled is
+  'When false, create-badminton-order refuses paymentMode "razorpay" and the '
+  'registration form hides the online option. Used to suspend card payments '
+  'during payment-gateway verification or an outage.';


### PR DESCRIPTION
Razorpay is verifying the website for live-mode activation. Card payments need to be off
until that completes, with offline registration kept open so teams can still enter.

## Why this isn't just hiding the button

`create-badminton-order` runs with `verify_jwt = false` behind an origin allowlist that
deliberately admits non-browser callers. Anything enforced only in the form is bypassable
with `curl`. The same gap already existed for `offline_enabled` — the server has never
checked it, so it was a UI hint rather than a control.

`payment_settings` gains `online_enabled`, and the Edge Function now reads both switches
before doing any work, returning **503** for a suspended method. Nothing reaches Razorpay
and no row is written.

## Behaviour

| online | offline | Result |
| --- | --- | --- |
| on | on | both offered, registrant chooses |
| **off** | **on** | offline only — what we're switching to now |
| on | off | online only (today's behaviour) |
| off | off | registration paused, clear notice, server refuses both |

The lookup **fails closed**. If we can't read the switches we can't know online payments
are meant to be suspended, and being certain of that is the whole point. The availability
cost is near zero — it reads the same database the registration row is about to be written
to, so if it's unreachable the request was failing anyway.

A project that has never saved settings keeps the pre-existing posture (online on, offline
off), matching the column defaults — so **applying the migration alone changes nothing**.

## Flipping it

One checkbox at `/menu/invoice-settings`. No PR, no Netlify build, no functions deploy to
re-enable after verification — which is the reason it lives in the database rather than in
a constant.

The form offers whichever methods are live, moves someone off a method switched off under
them, and shows a paused notice if neither is available. The admin page warns when both
are off.

## Verification

All six gates clean. 71 → 77 tests: online off refuses and creates no order; offline still
works while online is off; offline off refuses; both off closes everything; an unreadable
settings row refuses rather than assuming; no settings row keeps the old posture.

## Deploying this one needs three steps, not one

1. Merge — Netlify rebuilds the frontend
2. `supabase db push` — **the migration must be applied or the function's lookup returns nothing useful**
3. `supabase functions deploy create-badminton-order` — the switch is enforced here

Then tick offline on (with bank details filled) and online off at `/menu/invoice-settings`.