### PR TITLE
fix: stop the payment page reporting failure mid-payment

### DIFF
--- a/src/component/badminton/StepPayment.tsx
+++ b/src/component/badminton/StepPayment.tsx
@@ -73,11 +73,16 @@ export default function StepPayment() {
         phone: contact,
       };
 
-      // Fallback in case neither the failed nor dismiss handler fires.
-      const safety = window.setTimeout(() => {
-        setLoading(false);
-        showToast("Payment window did not respond. Please try again.", "error");
-      }, 20000);
+      // Last resort: if checkout fires none of handler / payment.failed /
+      // payment.error / ondismiss, the button would sit on "Processing..."
+      // forever. Reset it silently, and generously late. A real payment —
+      // card OTP, or approving a UPI request on a phone — takes minutes, so
+      // any delay short enough to feel "responsive" is short enough to fire
+      // in the middle of one that is going fine. And it must never toast:
+      // when this runs we have no idea whether the payment failed or is
+      // still in progress, so claiming failure is both wrong and an
+      // invitation to pay twice.
+      const safety = window.setTimeout(() => setLoading(false), 15 * 60 * 1000);
 
       const rzp = new window.Razorpay({
         key: keyId,
@@ -98,6 +103,7 @@ export default function StepPayment() {
         },
         theme: { color: "#EA580C" },
         handler: function (resp: RazorpaySuccess) {
+          window.clearTimeout(safety);
           sessionStorage.setItem("rzp_success", JSON.stringify({ ...resp, ...payloadForSuccess }));
           clearDraft();
           window.location.href = "/payment/success";


### PR DESCRIPTION
Found during the test-profile dress rehearsal before switching to the live Razorpay account. A successful ₹7,500 registration ended with an error toast on screen.

## The bug

`StepPayment.tsx` armed a 20-second timer alongside the Razorpay checkout:

```js
const safety = window.setTimeout(() => {
  setLoading(false);
  showToast("Payment window did not respond. Please try again.", "error");
}, 20000);
```

Twenty seconds is shorter than a normal payment. Entering card details and an OTP, or approving a UPI collect request on a phone, routinely takes longer than that. So the timer fired while checkout was open and going perfectly well.

It was cleared in `ondismiss`, `payment.failed` and `payment.error` — but not in `handler`, the success path. That omission is real but secondary: success arrives *after* t=20s, so clearing it there would not have prevented the toast. The premise of a 20-second deadline was the defect.

## Why it mattered beyond the toast

The timer also called `setLoading(false)`, re-enabling the Pay button. On desktop the Razorpay overlay covers it. On mobile, checkout can hand off to a UPI app and leave the page in view — so a user could return to a page reading *"Payment window did not respond. Please try again."* with a live Pay button, tap it, and create a second Razorpay order and a second PENDING row while the first payment was still being captured.

## The fix

Keep the timer — it is the only thing that recovers a genuinely wedged button — but make it silent and move it out to 15 minutes. When it fires we cannot distinguish a failed payment from one still in progress, so it must assert neither. Also clear it from the success handler, so all four terminal paths are symmetric.

Two lines of behaviour change. The real outcomes were already covered: success → `handler`, failure → `payment.failed`, user closes → `ondismiss`, init failure → `payment.error`, and a throwing `rzp.open()` → the existing `catch`.

## Testing

`npm run lint`, `npm run typecheck` and `npm run build` all pass.

No unit test: the repo has no frontend test harness (`npm test` runs only the Deno suite under `supabase/functions/`, and there is no vitest/jest/testing-library dependency). Adding one to cover a `setTimeout` seemed disproportionate — worth revisiting if the payment UI grows.

Verified by observation instead, on the test profile: open checkout, wait 45 seconds without paying, close it. Before, the error toast fires at t=20s; after, no toast at any point and the button returns to "Pay ₹1,500" via `ondismiss`.
