### PR TITLE
fix: stop the Tournaments header collapsing on mobile

### DIFF
--- a/src/component/tournament/LiveRecentWidget.tsx
+++ b/src/component/tournament/LiveRecentWidget.tsx
@@ -92,8 +92,11 @@ export default function LiveRecentWidget() {
   return (
     <MotionSection className="bg-gradient-to-b from-orange-50/70 to-transparent dark:from-slate-900/50 dark:to-transparent">
       <div className="mx-auto max-w-6xl px-4 py-12 sm:py-16">
-      <div className="flex items-center justify-between mb-4">
-        <div className="flex items-center gap-3">
+      {/* Stacks below `sm`: the heading, the pill group and the link together run
+          to roughly 520px, which does not fit a phone. Left as one row they only
+          shrink, and "View all" ends up broken across two lines. */}
+      <div className="flex flex-col gap-3 mb-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex flex-wrap items-center gap-3">
           <h2 className="font-display text-3xl sm:text-4xl font-extrabold tracking-tight uppercase text-slate-900 dark:text-slate-100"><span aria-hidden className="mr-3 inline-block h-6 w-1.5 -mb-0.5 rounded-full bg-gradient-to-b from-amber-400 to-orange-600" />Tournaments</h2>
           <div className="glass-panel-subtle inline-flex rounded-full p-1">
             {([
@@ -113,7 +116,7 @@ export default function LiveRecentWidget() {
             ))}
           </div>
         </div>
-        <Link to="/tournaments" className="text-sm link-accent">View all</Link>
+        <Link to="/tournaments" className="text-sm link-accent self-start whitespace-nowrap sm:self-auto">View all</Link>
       </div>
       {toast && <Toast message={toast.message} type={toast.type} />}
       {loading ? (

--- a/src/component/tournament/LiveRecentWidget.tsx
+++ b/src/component/tournament/LiveRecentWidget.tsx
@@ -15,18 +15,7 @@ import { calculateScoreCardsOnHome } from "../../";
 import useToast from "../../hook/useToast";
 import Toast from "../common/Toast";
 import { TailSpin } from "react-loader-spinner";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faFilter } from "@fortawesome/free-solid-svg-icons";
-
-type Tab = "live" | "upcoming" | "past";
-
-// Rendered twice — as pills on desktop, as a menu on mobile — so the labels
-// live here rather than inline in either one.
-const TABS: [Tab, string][] = [
-  ["live", "Live"],
-  ["upcoming", "Upcoming"],
-  ["past", "Past"],
-];
+import TabFilter, { type Tab } from "./TabFilter";
 
 export default function LiveRecentWidget() {
   const [events, setEvents] = useState<EventProps[]>([]);
@@ -39,7 +28,6 @@ export default function LiveRecentWidget() {
   const [loading, setLoading] = useState(true);
   const { toast, showToast } = useToast();
   const [tab, setTab] = useState<Tab>("live");
-  const [filterOpen, setFilterOpen] = useState(false);
   const [autoSwitchEnabled, setAutoSwitchEnabled] = useState(true);
 
   useEffect(() => {
@@ -104,61 +92,19 @@ export default function LiveRecentWidget() {
   return (
     <MotionSection className="bg-gradient-to-b from-orange-50/70 to-transparent dark:from-slate-900/50 dark:to-transparent">
       <div className="mx-auto max-w-6xl px-4 py-12 sm:py-16">
-      {/* The heading alone is ~240px of a phone's ~330px, so the pill group and
-          the link cannot sit beside it — they collapse to one icon below `sm`,
-          with everything moved into the menu it opens. */}
-      <div className="mb-4 flex flex-wrap items-center gap-3">
+      {/* The heading alone is ~240px of a phone's ~330px, so the filter and the
+          link cannot sit beside it — below `sm` TabFilter collapses to one icon
+          and takes the link into the menu it opens. */}
+      <div className="mb-4 flex flex-wrap items-center gap-x-3">
         <h2 className="font-display text-3xl sm:text-4xl font-extrabold tracking-tight uppercase text-slate-900 dark:text-slate-100"><span aria-hidden className="mr-3 inline-block h-6 w-1.5 -mb-0.5 rounded-full bg-gradient-to-b from-amber-400 to-orange-600" />Tournaments</h2>
-        <div className="hidden glass-panel-subtle rounded-full p-1 sm:inline-flex">
-          {TABS.map(([key, label]) => (
-            <button
-              key={key}
-              onClick={() => { setAutoSwitchEnabled(false); setTab(key); }}
-              className={`px-3 py-1.5 text-xs sm:text-sm rounded-full transition-all duration-200 ${
-                tab === key ? "glass-button-primary rounded-full" : "text-slate-600 dark:text-slate-300 hover:text-slate-900 dark:hover:text-white"
-              }`}
-            >
-              {label}
-            </button>
-          ))}
-        </div>
+        <TabFilter
+          value={tab}
+          onChange={(next) => { setAutoSwitchEnabled(false); setTab(next); }}
+          menuFooter={
+            <Link to="/tournaments" className="block rounded-xl px-3 py-2 text-sm link-accent">View all tournaments</Link>
+          }
+        />
         <Link to="/tournaments" className="ml-auto hidden whitespace-nowrap text-sm link-accent sm:block">View all</Link>
-        <button
-          type="button"
-          onClick={() => setFilterOpen((v) => !v)}
-          aria-expanded={filterOpen}
-          aria-controls="tournaments-filter"
-          className="glass-panel-subtle ml-auto inline-flex h-9 w-9 items-center justify-center rounded-full text-slate-600 transition-colors hover:text-slate-900 dark:text-slate-300 dark:hover:text-white sm:hidden"
-        >
-          <FontAwesomeIcon icon={faFilter} aria-hidden className="h-4 w-4" />
-          <span className="sr-only">Filter tournaments</span>
-        </button>
-      </div>
-
-      {/* Same max-height disclosure the site header uses, so there is no
-          click-outside or focus-trap logic to get wrong. The divider separates
-          the three filter values from the one navigation action. */}
-      <div
-        id="tournaments-filter"
-        className={`overflow-hidden transition-[max-height] duration-300 sm:hidden ${filterOpen ? "max-h-60" : "max-h-0"}`}
-      >
-        <div className="glass-panel-subtle mb-4 rounded-2xl p-2">
-          {TABS.map(([key, label]) => (
-            <button
-              key={key}
-              type="button"
-              onClick={() => { setAutoSwitchEnabled(false); setTab(key); setFilterOpen(false); }}
-              aria-current={tab === key ? "true" : undefined}
-              className={`block w-full rounded-xl px-3 py-2 text-left text-sm transition-colors ${
-                tab === key ? "glass-button-primary" : "text-slate-600 dark:text-slate-300"
-              }`}
-            >
-              {label}
-            </button>
-          ))}
-          <div className="my-1 border-t border-slate-200 dark:border-slate-700" />
-          <Link to="/tournaments" className="block rounded-xl px-3 py-2 text-sm link-accent">View all tournaments</Link>
-        </div>
       </div>
       {toast && <Toast message={toast.message} type={toast.type} />}
       {loading ? (

--- a/src/component/tournament/LiveRecentWidget.tsx
+++ b/src/component/tournament/LiveRecentWidget.tsx
@@ -15,6 +15,18 @@ import { calculateScoreCardsOnHome } from "../../";
 import useToast from "../../hook/useToast";
 import Toast from "../common/Toast";
 import { TailSpin } from "react-loader-spinner";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faFilter } from "@fortawesome/free-solid-svg-icons";
+
+type Tab = "live" | "upcoming" | "past";
+
+// Rendered twice — as pills on desktop, as a menu on mobile — so the labels
+// live here rather than inline in either one.
+const TABS: [Tab, string][] = [
+  ["live", "Live"],
+  ["upcoming", "Upcoming"],
+  ["past", "Past"],
+];
 
 export default function LiveRecentWidget() {
   const [events, setEvents] = useState<EventProps[]>([]);
@@ -26,8 +38,8 @@ export default function LiveRecentWidget() {
   const [limit, setLimit] = useState<number>(() => calculateScoreCardsOnHome());
   const [loading, setLoading] = useState(true);
   const { toast, showToast } = useToast();
-  type Tab = "live" | "upcoming" | "past";
   const [tab, setTab] = useState<Tab>("live");
+  const [filterOpen, setFilterOpen] = useState(false);
   const [autoSwitchEnabled, setAutoSwitchEnabled] = useState(true);
 
   useEffect(() => {
@@ -92,31 +104,61 @@ export default function LiveRecentWidget() {
   return (
     <MotionSection className="bg-gradient-to-b from-orange-50/70 to-transparent dark:from-slate-900/50 dark:to-transparent">
       <div className="mx-auto max-w-6xl px-4 py-12 sm:py-16">
-      {/* Stacks below `sm`: the heading, the pill group and the link together run
-          to roughly 520px, which does not fit a phone. Left as one row they only
-          shrink, and "View all" ends up broken across two lines. */}
-      <div className="flex flex-col gap-3 mb-4 sm:flex-row sm:items-center sm:justify-between">
-        <div className="flex flex-wrap items-center gap-3">
-          <h2 className="font-display text-3xl sm:text-4xl font-extrabold tracking-tight uppercase text-slate-900 dark:text-slate-100"><span aria-hidden className="mr-3 inline-block h-6 w-1.5 -mb-0.5 rounded-full bg-gradient-to-b from-amber-400 to-orange-600" />Tournaments</h2>
-          <div className="glass-panel-subtle inline-flex rounded-full p-1">
-            {([
-              ["live", "Live"],
-              ["upcoming", "Upcoming"],
-              ["past", "Past"],
-            ] as [Tab, string][]).map(([key, label]) => (
-              <button
-                key={key}
-                onClick={() => { setAutoSwitchEnabled(false); setTab(key); }}
-                className={`px-3 py-1.5 text-xs sm:text-sm rounded-full transition-all duration-200 ${
-                  tab === key ? "glass-button-primary rounded-full" : "text-slate-600 dark:text-slate-300 hover:text-slate-900 dark:hover:text-white"
-                }`}
-              >
-                {label}
-              </button>
-            ))}
-          </div>
+      {/* The heading alone is ~240px of a phone's ~330px, so the pill group and
+          the link cannot sit beside it — they collapse to one icon below `sm`,
+          with everything moved into the menu it opens. */}
+      <div className="mb-4 flex flex-wrap items-center gap-3">
+        <h2 className="font-display text-3xl sm:text-4xl font-extrabold tracking-tight uppercase text-slate-900 dark:text-slate-100"><span aria-hidden className="mr-3 inline-block h-6 w-1.5 -mb-0.5 rounded-full bg-gradient-to-b from-amber-400 to-orange-600" />Tournaments</h2>
+        <div className="hidden glass-panel-subtle rounded-full p-1 sm:inline-flex">
+          {TABS.map(([key, label]) => (
+            <button
+              key={key}
+              onClick={() => { setAutoSwitchEnabled(false); setTab(key); }}
+              className={`px-3 py-1.5 text-xs sm:text-sm rounded-full transition-all duration-200 ${
+                tab === key ? "glass-button-primary rounded-full" : "text-slate-600 dark:text-slate-300 hover:text-slate-900 dark:hover:text-white"
+              }`}
+            >
+              {label}
+            </button>
+          ))}
         </div>
-        <Link to="/tournaments" className="text-sm link-accent self-start whitespace-nowrap sm:self-auto">View all</Link>
+        <Link to="/tournaments" className="ml-auto hidden whitespace-nowrap text-sm link-accent sm:block">View all</Link>
+        <button
+          type="button"
+          onClick={() => setFilterOpen((v) => !v)}
+          aria-expanded={filterOpen}
+          aria-controls="tournaments-filter"
+          className="glass-panel-subtle ml-auto inline-flex h-9 w-9 items-center justify-center rounded-full text-slate-600 transition-colors hover:text-slate-900 dark:text-slate-300 dark:hover:text-white sm:hidden"
+        >
+          <FontAwesomeIcon icon={faFilter} aria-hidden className="h-4 w-4" />
+          <span className="sr-only">Filter tournaments</span>
+        </button>
+      </div>
+
+      {/* Same max-height disclosure the site header uses, so there is no
+          click-outside or focus-trap logic to get wrong. The divider separates
+          the three filter values from the one navigation action. */}
+      <div
+        id="tournaments-filter"
+        className={`overflow-hidden transition-[max-height] duration-300 sm:hidden ${filterOpen ? "max-h-60" : "max-h-0"}`}
+      >
+        <div className="glass-panel-subtle mb-4 rounded-2xl p-2">
+          {TABS.map(([key, label]) => (
+            <button
+              key={key}
+              type="button"
+              onClick={() => { setAutoSwitchEnabled(false); setTab(key); setFilterOpen(false); }}
+              aria-current={tab === key ? "true" : undefined}
+              className={`block w-full rounded-xl px-3 py-2 text-left text-sm transition-colors ${
+                tab === key ? "glass-button-primary" : "text-slate-600 dark:text-slate-300"
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+          <div className="my-1 border-t border-slate-200 dark:border-slate-700" />
+          <Link to="/tournaments" className="block rounded-xl px-3 py-2 text-sm link-accent">View all tournaments</Link>
+        </div>
       </div>
       {toast && <Toast message={toast.message} type={toast.type} />}
       {loading ? (

--- a/src/component/tournament/TabFilter.tsx
+++ b/src/component/tournament/TabFilter.tsx
@@ -1,0 +1,109 @@
+import { ReactNode, useState } from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faFilter } from "@fortawesome/free-solid-svg-icons";
+
+export type Tab = "live" | "upcoming" | "past";
+
+// Not exported: both call sites render this component rather than their own
+// copy of the pills, which is what let the two versions drift apart before.
+const TABS: [Tab, string][] = [
+  ["live", "Live"],
+  ["upcoming", "Upcoming"],
+  ["past", "Past"],
+];
+
+type Props = {
+  value: Tab;
+  onChange: (tab: Tab) => void;
+  /** Extra item shown under a divider in the mobile menu — e.g. a link away
+   *  from a preview section. Omitted on a page that is already the destination. */
+  menuFooter?: ReactNode;
+};
+
+/**
+ * The live/upcoming/past filter, in both the forms it needs to take.
+ *
+ * Above `sm` it is a pill group. Below it collapses to a single icon, because
+ * a section heading already takes ~240px of a phone's ~330px and the pills
+ * need ~215px more — left in one row they widen the document and the whole
+ * page scrolls sideways.
+ *
+ * The disclosure uses the same max-height transition as the site header, so
+ * there is no click-outside or focus-trap handling to get wrong.
+ *
+ * Both pages render this rather than their own copy: they had already drifted
+ * once (`text-xs` here, `text-sm` there) before this existed.
+ */
+export default function TabFilter({ value, onChange, menuFooter }: Props) {
+  const [open, setOpen] = useState(false);
+
+  const select = (tab: Tab) => {
+    onChange(tab);
+    setOpen(false);
+  };
+
+  return (
+    <>
+      <div className="hidden glass-panel-subtle rounded-full p-1 sm:inline-flex">
+        {TABS.map(([key, label]) => (
+          <button
+            key={key}
+            type="button"
+            onClick={() => onChange(key)}
+            className={`px-3 py-1.5 text-xs sm:text-sm rounded-full transition-all duration-200 ${
+              value === key
+                ? "glass-button-primary rounded-full"
+                : "text-slate-600 dark:text-slate-300 hover:text-slate-900 dark:hover:text-white"
+            }`}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        aria-controls="tournament-filter-menu"
+        className="glass-panel-subtle ml-auto inline-flex h-9 w-9 items-center justify-center rounded-full text-slate-600 transition-colors hover:text-slate-900 dark:text-slate-300 dark:hover:text-white sm:hidden"
+      >
+        <FontAwesomeIcon icon={faFilter} aria-hidden className="h-4 w-4" />
+        <span className="sr-only">Filter tournaments</span>
+      </button>
+
+      {/* Full-width so it drops below the header row rather than beside it.
+          Its spacing sits on the inner panel, inside the clipped box — a margin
+          on this element would leave a gap in the row while closed. Callers
+          pair this with `gap-x-*` rather than `gap-*` for the same reason. */}
+      <div
+        id="tournament-filter-menu"
+        className={`w-full overflow-hidden transition-[max-height] duration-300 sm:hidden ${
+          open ? "max-h-60" : "max-h-0"
+        }`}
+      >
+        <div className="glass-panel-subtle mt-3 rounded-2xl p-2">
+          {TABS.map(([key, label]) => (
+            <button
+              key={key}
+              type="button"
+              onClick={() => select(key)}
+              aria-current={value === key ? "true" : undefined}
+              className={`block w-full rounded-xl px-3 py-2 text-left text-sm transition-colors ${
+                value === key ? "glass-button-primary" : "text-slate-600 dark:text-slate-300"
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+          {menuFooter && (
+            <>
+              <div className="my-1 border-t border-slate-200 dark:border-slate-700" />
+              {menuFooter}
+            </>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/pages/Tournaments.tsx
+++ b/src/pages/Tournaments.tsx
@@ -52,7 +52,12 @@ export default function TournamentsPage() {
 
   return (
     <div className="mx-auto max-w-6xl px-4 py-12 sm:py-16">
-      <div className="flex items-center justify-between mb-4">
+      {/* flex-wrap, not nowrap: the title and the pill group come to ~400px,
+          more than a phone's ~330px. Without wrapping this row widened the
+          whole document, so the header and footer scrolled sideways with it.
+          Unlike the homepage widget the tabs stay visible here — filtering is
+          what this page is for. */}
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
         <h1 className="font-display text-3xl sm:text-4xl font-bold tracking-tight text-slate-900 dark:text-slate-100">Tournaments</h1>
         <div className="glass-panel-subtle inline-flex rounded-full p-1">
           {([
@@ -63,7 +68,7 @@ export default function TournamentsPage() {
             <button
               key={key}
               onClick={() => setTab(key)}
-              className={`px-3 py-1.5 text-sm rounded-full ${
+              className={`px-3 py-1.5 text-xs sm:text-sm rounded-full ${
                 tab === key ? "glass-button-primary rounded-full" : "text-slate-600 dark:text-slate-300 hover:text-slate-900 dark:hover:text-white"
               }`}
             >

--- a/src/pages/Tournaments.tsx
+++ b/src/pages/Tournaments.tsx
@@ -8,9 +8,8 @@ import type { EventTeam, Match, ScoreCardData, Team } from "../types/tournament"
 import { resolveTeamsForMatch } from "../tournament/resolve";
 import { toScoreCardData } from "../tournament/adapter";
 import ScoreCard from "../component/tournament/ScoreCard";
+import TabFilter, { type Tab } from "../component/tournament/TabFilter";
 import { MotionGrid, MotionItem } from "../component/common/motion";
-
-type Tab = "live" | "upcoming" | "past";
 
 export default function TournamentsPage() {
   const [tab, setTab] = useState<Tab>("live");
@@ -52,30 +51,14 @@ export default function TournamentsPage() {
 
   return (
     <div className="mx-auto max-w-6xl px-4 py-12 sm:py-16">
-      {/* flex-wrap, not nowrap: the title and the pill group come to ~400px,
-          more than a phone's ~330px. Without wrapping this row widened the
-          whole document, so the header and footer scrolled sideways with it.
-          Unlike the homepage widget the tabs stay visible here — filtering is
-          what this page is for. */}
-      <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+      {/* Title plus the pill group came to ~400px against a phone's ~330px, and
+          this container does not clip — so the row widened the whole document
+          and the header and footer scrolled sideways with it. TabFilter
+          collapses to an icon below `sm`. No menu footer: this page is where
+          "View all tournaments" would have gone. */}
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-x-3">
         <h1 className="font-display text-3xl sm:text-4xl font-bold tracking-tight text-slate-900 dark:text-slate-100">Tournaments</h1>
-        <div className="glass-panel-subtle inline-flex rounded-full p-1">
-          {([
-            ["live", "Live"],
-            ["upcoming", "Upcoming"],
-            ["past", "Past"],
-          ] as [Tab, string][]).map(([key, label]) => (
-            <button
-              key={key}
-              onClick={() => setTab(key)}
-              className={`px-3 py-1.5 text-xs sm:text-sm rounded-full ${
-                tab === key ? "glass-button-primary rounded-full" : "text-slate-600 dark:text-slate-300 hover:text-slate-900 dark:hover:text-white"
-              }`}
-            >
-              {label}
-            </button>
-          ))}
-        </div>
+        <TabFilter value={tab} onChange={setTab} />
       </div>
 
       {cards.length === 0 ? (


### PR DESCRIPTION
Spotted on the live site at a phone width: the **View all** link in the Tournaments section header is squeezed until it wraps onto two lines — "View" / "all" — and collides with the Live/Upcoming/Past pill group at the edge of the container.

## Cause

`LiveRecentWidget.tsx:95` was a single flex row with no wrapping and nothing hidden on small screens:

```jsx
<div className="flex items-center justify-between mb-4">
  <div className="flex items-center gap-3">
    <h2 className="… text-3xl sm:text-4xl … uppercase">Tournaments</h2>
    <div className="glass-panel-subtle inline-flex rounded-full p-1">Live | Upcoming | Past</div>
  </div>
  <Link to="/tournaments" className="text-sm link-accent">View all</Link>
</div>
```

The 30px uppercase heading is ~225px, the pill group ~225px, the link ~60px, plus the gap — about 520px of content in the ~330px a 360px phone leaves after `px-4`. `flex` defaults to `nowrap`, so the items shrink instead of wrapping, and the link is the one with the least to give.

`Highlights.tsx:49` and `:81` use the identical pattern but survive, because their carousel arrows are `hidden sm:flex` — on mobile only the heading remains. This header hid nothing *and* carried an extra control group, which is why it was the only one that broke.

## Fix

- `flex-col … sm:flex-row` — the link drops below the heading and pills on mobile. Same pattern already used across the registration flow (`StepEntries.tsx:378`, `StepOrganization.tsx:108`, `StepPayment.tsx:194`, `Hero.tsx:49`).
- `flex-wrap` on the inner group — the pills wrap under the heading on the narrowest screens rather than compressing it.
- `whitespace-nowrap` + `self-start` on the link — the specific defect; it can no longer split mid-phrase, and aligns left instead of stretching.

At `sm` and above the rendered layout is unchanged.

## Testing

`npm run lint`, `npm run typecheck` and `npm run build` pass.

Visual check is on the deploy preview at 360px and 320px: "View all" on its own line, on one line, inside the container; nothing overlapping; no horizontal scroll; and the single-row layout restored above 640px.
