### PR TITLE
fix: stop event card chips and the hero title cutting off on mobile

### DIFF
--- a/src/component/EventCard.tsx
+++ b/src/component/EventCard.tsx
@@ -82,16 +82,23 @@ const EventCard: React.FC<CardProps> = ({
             )}
           </div>
 
-          {/* CTA row - pushed to bottom */}
+          {/* CTA row - pushed to bottom.
+              flex-wrap rather than `flex-col sm:flex-row`: this card's width
+              comes from the grid in Event.tsx (1 / md:2 / lg:3 columns), not
+              from the viewport, so it is *widest* at 640-767px and narrowest
+              from md up. Any sm:/md: guess here is wrong at some column count
+              — at md the two controls came to ~322px against ~318px of card,
+              and both labels wrapped mid-phrase over four pixels. Let the row
+              wrap and the labels stay whole. */}
           <div className="mt-auto">
-            <div className="flex flex-col sm:flex-row gap-2 sm:justify-end">
+            <div className="flex flex-wrap gap-2 sm:justify-end">
               {/* Always show View Flyer if available */}
               {flyerUrl && (
                 <a
                   href={flyerUrl}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="glass-button-outline py-2 px-4 text-sm"
+                  className="glass-button-outline whitespace-nowrap py-2 px-4 text-sm"
                   aria-label={`View flyer for ${name}`}
                 >
                   View Flyer
@@ -105,7 +112,7 @@ const EventCard: React.FC<CardProps> = ({
                     href={registrationUrl}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="glass-button-primary py-2 px-4 text-sm"
+                    className="glass-button-primary whitespace-nowrap py-2 px-4 text-sm"
                     aria-label={`Register for ${name}`}
                   >
                     Register Now
@@ -113,14 +120,14 @@ const EventCard: React.FC<CardProps> = ({
                 ) : (
                   <Link
                     to={registrationUrl as string}
-                    className="glass-button-primary py-2 px-4 text-sm"
+                    className="glass-button-primary whitespace-nowrap py-2 px-4 text-sm"
                     aria-label={`Register for ${name}`}
                   >
                     Register Now
                   </Link>
                 )
               ) : (
-                <span className="inline-flex items-center justify-center rounded-full border border-amber-200 bg-amber-50 px-4 py-2 text-sm font-semibold text-amber-700 dark:border-amber-900 dark:bg-amber-950/50 dark:text-amber-300">
+                <span className="inline-flex items-center justify-center whitespace-nowrap rounded-xl border border-amber-200 bg-amber-50 px-4 py-2 text-sm font-semibold text-amber-700 dark:border-amber-900 dark:bg-amber-950/50 dark:text-amber-300">
                   Registration opening soon
                 </span>
               )}

--- a/src/component/EventCard.tsx
+++ b/src/component/EventCard.tsx
@@ -3,15 +3,9 @@ import { motion } from "framer-motion";
 import { Link } from "react-router-dom";
 import { EventProps } from "../types";
 import { formatDateLong } from "../utils/date";
+import { hasValidRegistration, isExternalUrl } from "../utils/registrationUrl";
 
 type CardProps = EventProps & { registrationUrl?: string };
-
-const isExternal = (url?: string) => !!url && /^https?:\/\//i.test(url);
-const isNA = (v?: string) => {
-  if (!v) return false;
-  const s = v.trim().toLowerCase();
-  return s === "na" || s === "n/a";
-};
 
 const EventCard: React.FC<CardProps> = ({
   name,
@@ -23,8 +17,7 @@ const EventCard: React.FC<CardProps> = ({
   description,
   registrationUrl,
 }) => {
-  const hasValidRegistration = registrationUrl && !isNA(registrationUrl);
-  
+
   return (
     <motion.article
       whileHover={{ y: -4 }}
@@ -59,30 +52,32 @@ const EventCard: React.FC<CardProps> = ({
             )}
           </header>
 
-          {/* Glassmorphic tags */}
+          {/* Glassmorphic tags.
+              `max-w-full`, not a fixed cap: a 120px cap truncated ordinary
+              values — "29th August 2026" needs ~139px and "Nahata Sports
+              Complex" ~175px, both of which fit the card and simply wrap.
+              Truncation is the fallback for a pathologically long value, not
+              the normal case.
+              The `truncate` sits on an inner span because .glass-pill is
+              inline-flex, and text-overflow does not apply to flex
+              containers — so `text-ellipsis` on the pill itself was a no-op
+              and the text was chopped with no ellipsis at all. A flex item is
+              blockified, so it works there; min-w-0 lets it shrink far enough
+              to actually ellipsize. */}
           <div className="flex flex-wrap gap-1.5 mb-4">
             {sport && (
-              <span
-                title={sport}
-                className="glass-pill-accent max-w-[120px] sm:max-w-[140px] whitespace-nowrap overflow-hidden text-ellipsis"
-              >
-                {sport}
+              <span title={sport} className="glass-pill-accent max-w-full">
+                <span className="min-w-0 truncate">{sport}</span>
               </span>
             )}
             {date && (
-              <span
-                title={formatDateLong(date)}
-                className="glass-pill max-w-[120px] sm:max-w-[140px] whitespace-nowrap overflow-hidden text-ellipsis font-medium"
-              >
-                {formatDateLong(date)}
+              <span title={formatDateLong(date)} className="glass-pill max-w-full font-medium">
+                <span className="min-w-0 truncate">{formatDateLong(date)}</span>
               </span>
             )}
             {location && (
-              <span
-                title={location}
-                className="glass-pill max-w-[120px] sm:max-w-[140px] whitespace-nowrap overflow-hidden text-ellipsis font-medium"
-              >
-                {location}
+              <span title={location} className="glass-pill max-w-full font-medium">
+                <span className="min-w-0 truncate">{location}</span>
               </span>
             )}
           </div>
@@ -103,9 +98,9 @@ const EventCard: React.FC<CardProps> = ({
                 </a>
               )}
               
-              {/* Register Now button - only show if there's a valid registration URL */}
-              {hasValidRegistration && (
-                isExternal(registrationUrl) ? (
+              {/* Register Now button if there's a valid registration URL, otherwise let people know it's coming */}
+              {hasValidRegistration(registrationUrl) ? (
+                isExternalUrl(registrationUrl) ? (
                   <a
                     href={registrationUrl}
                     target="_blank"
@@ -117,13 +112,17 @@ const EventCard: React.FC<CardProps> = ({
                   </a>
                 ) : (
                   <Link
-                    to={registrationUrl}
+                    to={registrationUrl as string}
                     className="glass-button-primary py-2 px-4 text-sm"
                     aria-label={`Register for ${name}`}
                   >
                     Register Now
                   </Link>
                 )
+              ) : (
+                <span className="inline-flex items-center justify-center rounded-full border border-amber-200 bg-amber-50 px-4 py-2 text-sm font-semibold text-amber-700 dark:border-amber-900 dark:bg-amber-950/50 dark:text-amber-300">
+                  Registration opening soon
+                </span>
               )}
             </div>
           </div>

--- a/src/component/Hero.tsx
+++ b/src/component/Hero.tsx
@@ -3,6 +3,7 @@ import { motion } from "framer-motion";
 import { Link } from "react-router-dom";
 import useEvents from "../hook/useEvents";
 import { parseFlexibleDate, formatDateLong } from "../utils/date";
+import { hasValidRegistration, isExternalUrl } from "../utils/registrationUrl";
 
 const Hero: React.FC = () => {
   const { eventsList } = useEvents();
@@ -19,6 +20,9 @@ const Hero: React.FC = () => {
     if (withTs.length > 0) return withTs.sort((a, b) => b.ts - a.ts)[0].e;
     return eventsList[0];
   }, [eventsList]);
+  const canRegisterInternally =
+    !!nextEvent && hasValidRegistration(nextEvent.registrationUrl) && !isExternalUrl(nextEvent.registrationUrl);
+  const registrationOpeningSoon = !!nextEvent && !hasValidRegistration(nextEvent.registrationUrl);
   return (
     <section className="relative overflow-hidden bg-slate-950">
       {/* Decorative accent layer — static, clipped, no copy */}
@@ -38,7 +42,11 @@ const Hero: React.FC = () => {
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.4 }}
           >
-            <h1 className="font-display font-black tracking-tight text-5xl sm:text-6xl lg:text-7xl text-white">
+            {/* text-4xl at the base size, not text-5xl: "MAHARASHTRA" is one
+                unbreakable word, and at 48px black uppercase it is wider than a
+                phone's content box — which the section's overflow-hidden would
+                clip rather than wrap. */}
+            <h1 className="font-display font-black tracking-tight text-4xl sm:text-6xl lg:text-7xl text-white">
               <span className="uppercase">Maharashtra Krida</span> <br />
               <span className="block mt-2 accent-gradient-text-bright text-2xl sm:text-3xl lg:text-4xl font-extrabold tracking-tight">Play, Compete, Celebrate...</span>
             </h1>
@@ -47,14 +55,21 @@ const Hero: React.FC = () => {
             </p>
 
             <div className="mt-6 flex flex-col sm:flex-row gap-3">
-              {nextEvent && nextEvent.registrationUrl && !/^https?:\/\//i.test(nextEvent.registrationUrl) && !/^\s*(na|n\/a)\s*$/i.test(nextEvent.registrationUrl) && (
+              {canRegisterInternally && (
                 <motion.div whileHover={{ y: -2 }} whileTap={{ scale: 0.98 }}>
                   <Link
-                    to={nextEvent.registrationUrl}
+                    to={nextEvent!.registrationUrl as string}
                     className="glass-button-primary px-6 py-3 text-base"
                   >
                     Register
                   </Link>
+                </motion.div>
+              )}
+              {registrationOpeningSoon && (
+                <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="inline-flex">
+                  <span className="inline-flex items-center justify-center rounded-xl border border-amber-400/40 bg-amber-400/10 px-6 py-3 text-base font-semibold text-amber-300">
+                    Registration opening soon
+                  </span>
                 </motion.div>
               )}
               <motion.div whileHover={{ y: -2 }} whileTap={{ scale: 0.98 }}>

--- a/src/utils/registrationUrl.ts
+++ b/src/utils/registrationUrl.ts
@@ -1,0 +1,11 @@
+// Values a registration URL field can hold that aren't a real, usable link —
+// left blank, an explicit "not applicable", or a placeholder anchor ("#")
+// someone typed while the real link wasn't ready yet.
+const INVALID_REGISTRATION_VALUES = new Set(["", "#", "na", "n/a"]);
+
+export const hasValidRegistration = (url?: string): boolean => {
+  if (!url) return false;
+  return !INVALID_REGISTRATION_VALUES.has(url.trim().toLowerCase());
+};
+
+export const isExternalUrl = (url?: string): boolean => !!url && /^https?:\/\//i.test(url);


### PR DESCRIPTION
Event card chips were being chopped mid-word on a phone — "29th August 202", "Nahata Sports C" — with no ellipsis to indicate it.

## Chips

Two separate causes.

**The cap was too small.** At 360px the card offers ~298px of content width. `Badminton` is ~84px, `29th August 2026` ~139px, `Nahata Sports Complex` ~175px — the first two fit on one line and the third fits alone on the next. `max-w-[120px]` was forcing truncation on values that never needed it.

**The ellipsis was a no-op.** `.glass-pill` is `inline-flex` (`design-system.css:34`), and `text-overflow` does not apply to flex containers. So `text-ellipsis` on the pill did nothing, `overflow-hidden` clipped the text, and you got a hard cut with no "…".

Fix: `max-w-full` so a chip can never exceed the card, and move `truncate` onto an inner `<span>`. A flex item is blockified, so `text-overflow` works there; `min-w-0` lets it shrink far enough to actually ellipsize. Truncation becomes the fallback for a pathologically long value rather than the normal path.

## Hero title

`Hero.tsx` carried `text-5xl` with no smaller mobile size — the only heading on the site that skipped one. "MAHARASHTRA" is a single unbreakable 11-character token, ~365px at 48px Poppins Black uppercase against a ~330px content box, and the section has `overflow-hidden`, so it clipped mid-letter rather than wrapping. Now `text-4xl sm:text-6xl lg:text-7xl`.

## registrationUrl

Both files already imported `src/utils/registrationUrl.ts`, which was untracked — so this had to land with them. It treats `""`, `"#"`, `"na"` and `"n/a"` as non-links, so an event with no registration URL yet shows "Registration opening soon" rather than a button pointing nowhere.

## Testing

`npm run lint`, `npm run typecheck` and `npm run build` pass.

Visual check on the deploy preview at 360px: all three chips readable in full, wrapping rather than clipped; hero title fits without being cut.

## Not included

Two things visible in the same screenshot, left alone as design calls rather than bugs:

- The flyer image is `aspect-[4/3]` with `object-cover`, so a text-heavy poster always gets cropped. `object-contain` would show it whole but letterbox it.
- The gap between chips and "View Flyer" is `mt-auto` pinning the CTA to the bottom of an equal-height card — correct with several cards in a row, odd with one.
