### PR TITLE
fix: cards rendered invisible after paging or changing tab

### DIFF
--- a/src/component/tournament/LiveRecentWidget.tsx
+++ b/src/component/tournament/LiveRecentWidget.tsx
@@ -111,14 +111,17 @@ export default function LiveRecentWidget() {
         <div className="flex items-center justify-center py-10">
           <TailSpin color={SPINNER_COLOR} height={40} width={40} />
         </div>
-      ) : cards.length === 0 ? (
+      ) : /* MotionGrid below carries key={tab}: it staggers its children, so it
+             drives them, and cards mounted by a later tab would stay at opacity
+             0 unless the container remounts. */
+      cards.length === 0 ? (
         <p className="text-sm text-slate-600 dark:text-slate-400">
           {tab === "live" && "No live matches currently."}
           {tab === "upcoming" && "No upcoming matches."}
           {tab === "past" && "No past matches."}
         </p>
       ) : (
-        <MotionGrid className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+        <MotionGrid key={tab} className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
           {cards.map((c) => (
             <MotionItem key={c.matchId} whileHover={{ y: -4 }} className="h-full">
               <Link to="/tournaments" className="block h-full">

--- a/src/pages/Event.tsx
+++ b/src/pages/Event.tsx
@@ -9,7 +9,6 @@ import useEvents from "../hook/useEvents";
 import usePagination from "../hook/usePagination";
 
 export default function Event() {
-  console.log(calculateEventsPerPage())
   const [eventsPerPage] = useState(calculateEventsPerPage())
 
   const { eventsList, loading , error } = useEvents()
@@ -44,11 +43,22 @@ export default function Event() {
   return (
     <div className="mx-auto max-w-6xl px-4 py-12 sm:py-16">
       <h1 className="font-display text-3xl sm:text-4xl font-bold tracking-tight text-slate-900 dark:text-slate-100 mb-4">Upcoming Events</h1>
+      {/* key={currentPage} remounts the container on every page change.
+          staggerChildren means the parent drives its children — a child with
+          only `variants` never animates itself. The parent ran that animation
+          once, so cards mounted by a later page stayed at `hidden`, i.e.
+          opacity 0: present, sized, invisible.
+
+          animate rather than whileInView: after clicking a page button the
+          user is at the bottom of the page, so a freshly remounted grid can be
+          above the fold with no intersection to observe, which would reproduce
+          the same blank. This grid sits right under the h1 and is in view on
+          load anyway, so nothing is lost. */}
       <motion.div
+        key={currentPage}
         className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3 sm:gap-4 lg:gap-5"
         initial="hidden"
-        whileInView="show"
-        viewport={{ once: true, margin: "-40px" }}
+        animate="show"
         variants={{
           hidden: { opacity: 1 },
           show: { opacity: 1, transition: { staggerChildren: 0.06 } }

--- a/src/pages/Tournaments.tsx
+++ b/src/pages/Tournaments.tsx
@@ -61,10 +61,13 @@ export default function TournamentsPage() {
         <TabFilter value={tab} onChange={setTab} />
       </div>
 
+      {/* MotionGrid carries key={tab} below: it staggers its children, which
+          means it drives them, so cards mounted by a later filter would stay at
+          opacity 0 unless the container remounts. Same in LiveRecentWidget. */}
       {cards.length === 0 ? (
         <p className="text-slate-600 dark:text-slate-400">No live matches found.</p>
       ) : (
-        <MotionGrid className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        <MotionGrid key={tab} className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
           {cards.map((c) => (
             <MotionItem key={c.matchId} className="h-full">
               <ScoreCard data={c} />


### PR DESCRIPTION
On `/upcoming-events` at phone width, page 1 shows one event; clicking **2** shows nothing, and clicking **1** again also shows nothing. Nothing recovers short of a reload.

## The cards were never missing — they were invisible

The blank region between the title and the pagination is about one card tall, because the card is in the DOM, sized, at `opacity: 0`.

`Event.tsx` wrapped the grid in a staggered container:

```jsx
<motion.div initial="hidden" whileInView="show" viewport={{ once: true, margin: "-40px" }}
  variants={{ hidden: { opacity: 1 }, show: { opacity: 1, transition: { staggerChildren: 0.06 } } }}>
  {currentData().map((event) => (
    <motion.div variants={{ hidden: { opacity: 0, y: 10 }, show: { opacity: 1, y: 0 } }}>
```

`staggerChildren` means **the parent drives its children** — a child carrying only `variants` never animates itself, it waits to be told. The parent ran that animation exactly once (`whileInView` + `once: true`).

So the first paint works, because the children exist when the parent animates. Changing page unmounts those children and mounts new ones into a parent that has already finished, and nothing ever moves them off `hidden`. Going back to page 1 mounts *fresh* elements with the same fate — which is why nothing recovers.

`calculateEventsPerPage()` returning 1 below 640px is correct, and not part of this: two events genuinely means two pages. It is only why the bug is phone-only — on a laptop both events fit on page 1 and nobody ever pages.

## Fix

Remount the container per page so the animation re-runs, and use `animate` rather than `whileInView` on that grid: after tapping a page button the reader is at the *bottom* of the page, so a freshly remounted grid can sit above the fold with no intersection to observe — which would reproduce the same blank. That grid is directly under the `h1` and in view on load, so the scroll-reveal was doing nothing there anyway.

## Beyond the reported bug

Any swap of children under one of these grids hits this, not just pagination. `MotionGrid` has the same shape, and two call sites swap children on tab change — so both get `key={tab}`:

- `LiveRecentWidget.tsx` — Live / Upcoming / Past on the homepage
- `Tournaments.tsx` — the same filter, including the mobile filter menu added in #29, where changing filter could have rendered results invisible and looked like the filter simply did nothing

Rejected: making `MotionItem` self-animating would fix every case centrally, but it discards the stagger that is the wrapper's whole purpose and changes motion on every page using it.

Also removes a `console.log(calculateEventsPerPage())` that was running on every render of the events page in production.

## Testing

`npm run lint`, `npm run typecheck` and `npm run build` pass.

On the preview at 375px: `/upcoming-events` through 1 → 2 → 1, cards visible at each step and fading in rather than appearing flat; then the Live/Upcoming/Past filters on `/` and `/tournaments`.
