### PR TITLE
Validate upload files and surface real backend error messages

### DIFF
--- a/src/component/EventForm.tsx
+++ b/src/component/EventForm.tsx
@@ -2,6 +2,8 @@ import React, { useState } from "react";
 import { toast } from "react-toastify";
 import { addEvent } from "../services/eventService";
 import { uploadImage } from "../services/storageService";
+import { errorMessage } from "../services/error";
+import { validateImageFile, validateUploadFile } from "../utils/fileValidation";
 import PageLoader from "./PageLoader";
 import useEvents from "../hook/useEvents";
 
@@ -26,7 +28,15 @@ const EventForm = () => {
     const { name, files } = e.target;
     if (name === "imageFile" || name === "flyerFile") {
       if (files && files[0]) {
-        name === "imageFile" ? setImageFile(files[0]) : setFlyerFile(files[0]);
+        const file = files[0];
+        const validationError =
+          name === "imageFile" ? validateImageFile(file) : validateUploadFile(file, ["image/", "application/pdf"]);
+        if (validationError) {
+          toast.error(validationError);
+          e.target.value = "";
+          return;
+        }
+        name === "imageFile" ? setImageFile(file) : setFlyerFile(file);
       }
     } else {
       setFormData({ ...formData, [e.target.name]: e.target.value });
@@ -35,38 +45,51 @@ const EventForm = () => {
 
   const handleSubmit = async (e: React.ChangeEvent<HTMLFormElement>) => {
     e.preventDefault();
-    if (imageFile && flyerFile) {
-      try {
-        setLoading(true);
-        const uploadFilesPromises = [uploadImage(imageFile, "images"), uploadImage(flyerFile, "flyers")];
-        const [imageUrl, flyerUrl] = await Promise.all(uploadFilesPromises);
-        await addEvent({
-          ...formData,
-          imageUrl,
-          flyerUrl,
-        });
-        toast.success("Event added successfully.");
-        setFormData({
-          name: "",
-          sport: "",
-          date: "",
-          location: "",
-          imageUrl: "",
-          flyerUrl: "",
-          registrationUrl: "",
-          description: "",
-        });
-        setImageFile(null);
-        setFlyerFile(null);
-        handleEventChange();
-      } catch (error) {
-        console.error("Error adding document: ", error);
-        toast.error("Failed to add event.");
-      } finally {
-        setLoading(false);
-      }
-    } else {
+    if (!imageFile) {
       toast.error("Please upload an image file.");
+      return;
+    }
+
+    setLoading(true);
+    let imageUrl: string;
+    let flyerUrl: string;
+    try {
+      [imageUrl, flyerUrl] = await Promise.all([
+        uploadImage(imageFile, "images"),
+        flyerFile ? uploadImage(flyerFile, "flyers") : Promise.resolve(""),
+      ]);
+    } catch (error) {
+      console.error("EventForm: image/flyer upload failed", error);
+      toast.error(errorMessage(error));
+      setLoading(false);
+      return;
+    }
+
+    try {
+      await addEvent({
+        ...formData,
+        imageUrl,
+        flyerUrl,
+      });
+      toast.success("Event added successfully.");
+      setFormData({
+        name: "",
+        sport: "",
+        date: "",
+        location: "",
+        imageUrl: "",
+        flyerUrl: "",
+        registrationUrl: "",
+        description: "",
+      });
+      setImageFile(null);
+      setFlyerFile(null);
+      handleEventChange();
+    } catch (error) {
+      console.error("EventForm: addEvent failed", error);
+      toast.error(errorMessage(error));
+    } finally {
+      setLoading(false);
     }
   };
 
@@ -157,6 +180,7 @@ const EventForm = () => {
       <input
         type="file"
         name="imageFile"
+        accept="image/*"
         onChange={handleChange}
         className="glass-file-input w-full"
       />
@@ -166,11 +190,12 @@ const EventForm = () => {
         className="block text-slate-900 dark:text-slate-100 text-sm font-bold mb-2"
         htmlFor="flyerUrl"
       >
-        Flyer URL
+        Flyer URL (optional)
       </label>
       <input
         type="file"
         name="flyerFile"
+        accept="image/*,application/pdf"
         onChange={handleChange}
         className="glass-file-input w-full"
       />
@@ -180,14 +205,14 @@ const EventForm = () => {
         className="block text-slate-900 dark:text-slate-100 text-sm font-bold mb-2"
         htmlFor="registrationUrl"
       >
-        Registration URL
+        Registration URL (optional)
       </label>
       <input
         type="text"
         name="registrationUrl"
         value={formData.registrationUrl}
         onChange={handleChange}
-        placeholder="Registration URL"
+        placeholder="Leave blank to show &quot;Registration opening soon&quot;"
         className="glass-input w-full py-2 px-3"
       />
     </div>
@@ -210,7 +235,8 @@ const EventForm = () => {
     <div className="flex items-center justify-between">
       <button
         type="submit"
-        className="glass-button-primary w-full py-2 px-4"
+        disabled={loading}
+        className="glass-button-primary w-full py-2 px-4 disabled:opacity-60"
       >
         Add Event
       </button>

--- a/src/component/GalleryForm.tsx
+++ b/src/component/GalleryForm.tsx
@@ -1,5 +1,7 @@
 import { useState } from "react";
 import { uploadImage } from "../services/storageService";
+import { errorMessage } from "../services/error";
+import { validateImageFile } from "../utils/fileValidation";
 import PageLoader from "./PageLoader";
 import useToast from "../hook/useToast";
 import Toast from "./common/Toast";
@@ -16,7 +18,16 @@ export default function GalleryForm({ onAdded }: Props) {
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value, files } = e.target;
     if (name === "imageFile") {
-      if (files?.[0]) setFile(files[0]);
+      if (files?.[0]) {
+        const picked = files[0];
+        const validationError = validateImageFile(picked);
+        if (validationError) {
+          showToast(validationError, "error");
+          e.target.value = "";
+          return;
+        }
+        setFile(picked);
+      }
     } else {
       setForm((f) => ({ ...f, [name]: value }));
     }
@@ -30,17 +41,27 @@ export default function GalleryForm({ onAdded }: Props) {
       showToast("Please choose an image.", "error");
       return;
     }
+
+    setLoading(true);
+    let imageUrl: string;
     try {
-      setLoading(true);
-      const imageUrl = await upload(file);
+      imageUrl = await upload(file);
+    } catch (err) {
+      console.error("GalleryForm: image upload failed", err);
+      showToast(errorMessage(err), "error");
+      setLoading(false);
+      return;
+    }
+
+    try {
       await addGalleryItem({ imageUrl, title: form.title?.trim() || undefined, description: form.description?.trim() || undefined, alt: form.alt?.trim() || undefined });
       showToast("Gallery item added.", "success");
       setForm({});
       setFile(null);
       onAdded?.();
     } catch (err) {
-      console.error(err);
-      showToast("Failed to add item.", "error");
+      console.error("GalleryForm: addGalleryItem failed", err);
+      showToast(errorMessage(err), "error");
     } finally {
       setLoading(false);
     }
@@ -72,7 +93,7 @@ export default function GalleryForm({ onAdded }: Props) {
           <input name="imageFile" type="file" accept="image/*" onChange={onChange} className="glass-file-input w-full" />
         </div>
         <div className="flex items-center justify-between">
-          <button type="submit" className="glass-button-primary py-2 px-4">Add</button>
+          <button type="submit" disabled={loading} className="glass-button-primary py-2 px-4 disabled:opacity-60">Add</button>
         </div>
       </form>
     </>

--- a/src/component/GalleryList.tsx
+++ b/src/component/GalleryList.tsx
@@ -8,6 +8,7 @@ import Pagination from "./Pagination";
 import useToast from "../hook/useToast";
 import Toast from "./common/Toast";
 import { GalleryItem, deleteGalleryItem, listGallery } from "../services/galleryService";
+import { errorMessage } from "../services/error";
 
 type Props = { refreshKey?: number };
 
@@ -39,7 +40,8 @@ export default function GalleryList({ refreshKey }: Props) {
       setItems((list) => list.filter((x) => x.id !== id));
       showToast("Item deleted.", "success");
     } catch (e) {
-      showToast("Failed to delete.", "error");
+      console.error("GalleryList: delete failed", e);
+      showToast(errorMessage(e), "error");
     }
   };
 

--- a/src/component/HomepageForm.tsx
+++ b/src/component/HomepageForm.tsx
@@ -3,6 +3,8 @@ import React, { useState } from "react";
 import { SliderImageInput } from "../types";
 import useHomepageContent from "../hook/useHomepage";
 import { uploadImage } from "../services/storageService";
+import { errorMessage } from "../services/error";
+import { validateImageFile } from "../utils/fileValidation";
 import { TailSpin } from "react-loader-spinner";
 import Toast from "./common/Toast";
 import useToast from "../hook/useToast";
@@ -18,6 +20,7 @@ const HomepageForm: React.FC = () => {
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [isUpdating, setIsUpdating] = useState(false);
   const [updateId, setUpdateId] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
 
   const { toast, showToast } = useToast();
 
@@ -25,7 +28,14 @@ const HomepageForm: React.FC = () => {
 
   const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     if (event.target.files && event.target.files[0]) {
-      setSelectedFile(event.target.files[0]);
+      const file = event.target.files[0];
+      const validationError = validateImageFile(file);
+      if (validationError) {
+        showToast(validationError, "error");
+        event.target.value = "";
+        return;
+      }
+      setSelectedFile(file);
     }
   };
 
@@ -42,22 +52,37 @@ const HomepageForm: React.FC = () => {
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    if (selectedFile) {
-      try {
-        const imageUrl = await uploadFiles(selectedFile, "sliderImages");
-        showToast("Image uploaded successfully.", "success");
-        const completeData = { ...formData, imageUrl };
-        if (isUpdating && updateId) {
-          await handleUpdateContent(updateId, completeData);
-        } else {
-          await handleAddContent(completeData);
-          showToast("Content added successfully.", "success");
-        }
-        resetForm();
-      } catch (error) {
-        console.error("Error handling the form submission:", error);
-        showToast("Failed to add content.", "error");
+    if (!selectedFile) {
+      showToast("Please choose an image.", "error");
+      return;
+    }
+
+    setSubmitting(true);
+    let imageUrl: string;
+    try {
+      imageUrl = await uploadFiles(selectedFile, "sliderImages");
+    } catch (error) {
+      console.error("HomepageForm: image upload failed", error);
+      showToast(errorMessage(error), "error");
+      setSubmitting(false);
+      return;
+    }
+
+    try {
+      const completeData = { ...formData, imageUrl };
+      if (isUpdating && updateId) {
+        await handleUpdateContent(updateId, completeData);
+        showToast("Content updated successfully.", "success");
+      } else {
+        await handleAddContent(completeData);
+        showToast("Content added successfully.", "success");
       }
+      resetForm();
+    } catch (error) {
+      console.error("HomepageForm: save failed", error);
+      showToast(errorMessage(error), "error");
+    } finally {
+      setSubmitting(false);
     }
   };
 
@@ -90,10 +115,10 @@ const HomepageForm: React.FC = () => {
         <label className="block text-slate-600 dark:text-slate-300 text-sm font-bold mb-2" htmlFor="imageFile">
           Image
         </label>
-        <input type="file" name="imageFile" onChange={handleFileChange} className="glass-file-input w-full" required />
+        <input type="file" name="imageFile" accept="image/*" onChange={handleFileChange} className="glass-file-input w-full" required />
       </div>
       <div className="flex items-center justify-between">
-        <button type="submit" className="glass-button-primary font-bold py-2 px-4">
+        <button type="submit" disabled={submitting} className="glass-button-primary font-bold py-2 px-4 disabled:opacity-60">
           Add Content
         </button>
       </div>

--- a/src/component/HomepageList.tsx
+++ b/src/component/HomepageList.tsx
@@ -7,6 +7,7 @@ import { faTrash } from '@fortawesome/free-solid-svg-icons';
 import { calculateEventsPerPage } from '..';
 import useToast from '../hook/useToast';
 import Toast from './common/Toast';
+import { errorMessage } from '../services/error';
 
 const HomepageList: React.FC = () => {
     const [contentPerPage] = useState(calculateEventsPerPage());
@@ -19,7 +20,8 @@ const HomepageList: React.FC = () => {
             await handleDeleteContent(id);
             showToast('Content deleted successfully.', 'success');
         } catch (error) {
-            showToast('Failed to delete content.', 'error');
+            console.error('HomepageList: delete failed', error);
+            showToast(errorMessage(error), 'error');
         }
     };
 

--- a/src/component/NewsForm.tsx
+++ b/src/component/NewsForm.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from "react";
 import PageLoader from "./PageLoader";
 import { uploadImage } from "../services/storageService";
+import { errorMessage } from "../services/error";
+import { validateImageFile } from "../utils/fileValidation";
 import useToast from "../hook/useToast";
 import Toast from "./common/Toast";
 import { addNewsItem } from "../services/newsService";
@@ -24,7 +26,7 @@ export default function NewsForm({ onAdded }: Props) {
         const list = await getEvents();
         setEvents(list);
       } catch (e) {
-        // ignore; dropdown will be empty
+        console.error("NewsForm: failed to load events for dropdown", e);
       } finally {
         setEventsLoading(false);
       }
@@ -39,7 +41,15 @@ export default function NewsForm({ onAdded }: Props) {
     const target = e.target;
     if (target instanceof HTMLInputElement && target.name === "imageFile") {
       const picked = target.files?.[0];
-      if (picked) setFile(picked);
+      if (picked) {
+        const validationError = validateImageFile(picked);
+        if (validationError) {
+          showToast(validationError, "error");
+          target.value = "";
+          return;
+        }
+        setFile(picked);
+      }
       return;
     }
     setForm((f) => ({ ...f, [target.name]: target.value }));
@@ -49,21 +59,35 @@ export default function NewsForm({ onAdded }: Props) {
 
   const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    if (!form.title.trim() || !form.content?.trim()) {
-      showToast("Title and content are required.", "error");
+    if (!form.title.trim()) {
+      showToast("Title is required.", "error");
       return;
     }
+    if (!form.content?.trim()) {
+      showToast("Content is required.", "error");
+      return;
+    }
+
+    setLoading(true);
+    let imageUrl: string | undefined;
     try {
-      setLoading(true);
-      const imageUrl = file ? await upload(file) : undefined;
+      imageUrl = file ? await upload(file) : undefined;
+    } catch (e) {
+      console.error("NewsForm: image upload failed", e);
+      showToast(errorMessage(e), "error");
+      setLoading(false);
+      return;
+    }
+
+    try {
       await addNewsItem({ title: form.title.trim(), summary: form.summary?.trim() || undefined, content: form.content?.trim(), imageUrl, eventId: form.eventId || undefined });
       showToast("News added.", "success");
       setForm({ title: "" });
       setFile(null);
       onAdded?.();
     } catch (e) {
-      console.error(e);
-      showToast("Failed to add news.", "error");
+      console.error("NewsForm: addNewsItem failed", e);
+      showToast(errorMessage(e), "error");
     } finally {
       setLoading(false);
     }
@@ -111,7 +135,7 @@ export default function NewsForm({ onAdded }: Props) {
           <input name="imageFile" type="file" accept="image/*" onChange={onChange} className="glass-file-input w-full" />
         </div>
         <div className="flex items-center justify-between">
-          <button type="submit" className="glass-button-primary py-2 px-4">Add</button>
+          <button type="submit" disabled={loading} className="glass-button-primary py-2 px-4 disabled:opacity-60">Add</button>
         </div>
       </form>
     </>

--- a/src/component/NewsList.tsx
+++ b/src/component/NewsList.tsx
@@ -5,6 +5,7 @@ import { faTrash } from "@fortawesome/free-solid-svg-icons";
 import useToast from "../hook/useToast";
 import Toast from "./common/Toast";
 import { NewsItem, deleteNewsItem, listNews } from "../services/newsService";
+import { errorMessage } from "../services/error";
 import usePagination from "../hook/usePagination";
 import Pagination from "./Pagination";
 import { calculateEventsPerPage } from "..";
@@ -39,7 +40,8 @@ export default function NewsList({ refreshKey }: Props) {
       setItems((list) => list.filter((x) => x.id !== id));
       showToast("News deleted.", "success");
     } catch (e) {
-      showToast("Failed to delete.", "error");
+      console.error("NewsList: delete failed", e);
+      showToast(errorMessage(e), "error");
     }
   };
 

--- a/src/component/tournament/admin/MatchesTab.tsx
+++ b/src/component/tournament/admin/MatchesTab.tsx
@@ -7,6 +7,7 @@ import { updateMatch } from "../../../services/matchService";
 import useToast from "../../../hook/useToast";
 import Toast from "../../common/Toast";
 import { TailSpin } from "react-loader-spinner";
+import { errorMessage } from "../../../services/error";
 
 type Props = {
   event: EventProps;
@@ -403,7 +404,7 @@ export default function MatchesTab({ event, matches, teams, eventTeams, refreshM
                           cancelEditing(m.id);
                         } catch(error) {
                           console.error("Error updating match:", error);
-                          showToast("Failed to update match", "error");
+                          showToast(errorMessage(error), "error");
                         } finally {
                           setSavingIds((s) => { const n = new Set(s); n.delete(m.id); return n; });
                         }
@@ -431,7 +432,7 @@ export default function MatchesTab({ event, matches, teams, eventTeams, refreshM
                         await refreshMatches();
                       } catch(error) {
                         console.error("Error updating match:", error);
-                        showToast("Failed to update match", "error");
+                        showToast(errorMessage(error), "error");
                       } finally {
                         setSavingIds((s) => { const n = new Set(s); n.delete(m.id); return n; });
                       }

--- a/src/component/tournament/admin/ScheduleTab.tsx
+++ b/src/component/tournament/admin/ScheduleTab.tsx
@@ -8,6 +8,7 @@ import { createTeam } from "../../../services/teamService";
 import useToast from "../../../hook/useToast";
 import Toast from "../../common/Toast";
 import { TailSpin } from "react-loader-spinner";
+import { errorMessage } from "../../../services/error";
 
 type Props = {
   eventId: ID;
@@ -55,7 +56,10 @@ export default function ScheduleTab({ eventId, teams, eventTeams, refreshMatches
           disabled={creatingMatch}
           className="glass-button-primary w-full px-4 py-2 inline-flex items-center justify-center gap-2 disabled:opacity-60"
           onClick={async () => {
-            if (!teamAId || !teamBId) return;
+            if (!teamAId || !teamBId) {
+              showToast("Select both teams before creating a match.", "error");
+              return;
+            }
             try {
               setCreatingMatch(true);
               const payload: NewMatch = { eventId, teamAId, teamBId, scheduledAt: toEpoch(scheduledAt), venue: venue || undefined, status: "upcoming" };
@@ -63,8 +67,9 @@ export default function ScheduleTab({ eventId, teams, eventTeams, refreshMatches
               showToast("Match created", "success");
               setTeamAId(""); setTeamBId(""); setScheduledAt(""); setVenue("");
               await refreshMatches();
-            } catch {
-              showToast("Failed to create match", "error");
+            } catch (err) {
+              console.error("ScheduleTab: createMatch failed", err);
+              showToast(errorMessage(err), "error");
             } finally {
               setCreatingMatch(false);
             }
@@ -82,13 +87,15 @@ export default function ScheduleTab({ eventId, teams, eventTeams, refreshMatches
         onChange={async (e) => {
           const file = e.target.files?.[0];
           if (!file) return;
-          let parsed: ParsedSchedule[] = [];
+          let parsed: ParsedSchedule[];
           try {
             parsed = await parseScheduleXlsx(file);
             setImportRows(parsed);
             showToast(`Parsed ${parsed.length} rows`, "success");
-          } catch {
-            showToast("Failed to parse Excel", "error");
+          } catch (err) {
+            console.error("ScheduleTab: parseScheduleXlsx failed", err);
+            showToast(`Failed to parse Excel: ${errorMessage(err)}`, "error");
+            return;
           }
           const names = new Set<string>();
           const allowedNames = new Map<string, string>();
@@ -112,6 +119,7 @@ export default function ScheduleTab({ eventId, teams, eventTeams, refreshMatches
               disabled={creatingMissing}
               className="mt-2 glass-button-secondary w-full px-4 py-1.5 text-sm inline-flex items-center justify-center gap-2"
               onClick={async () => {
+                let currentName = "";
                 try {
                   setCreatingMissing(true);
                   const nameToId = new Map<string, string>();
@@ -120,6 +128,7 @@ export default function ScheduleTab({ eventId, teams, eventTeams, refreshMatches
                     if (t.short) nameToId.set(t.short.toLowerCase(), t.id);
                   }
                   for (const name of missingNames) {
+                    currentName = name;
                     const key = name.toLowerCase();
                     let id = nameToId.get(key);
                     if (!id) id = await createTeam({ name });
@@ -139,8 +148,9 @@ export default function ScheduleTab({ eventId, teams, eventTeams, refreshMatches
                   }
                   setMissingNames(Array.from(newMissing));
                   showToast("Missing teams resolved", "success");
-                } catch {
-                  showToast("Failed to resolve missing teams", "error");
+                } catch (err) {
+                  console.error("ScheduleTab: resolve missing teams failed", err);
+                  showToast(`Failed to resolve missing teams (stopped at "${currentName}"): ${errorMessage(err)}`, "error");
                 } finally {
                   setCreatingMissing(false);
                 }
@@ -154,6 +164,7 @@ export default function ScheduleTab({ eventId, teams, eventTeams, refreshMatches
             className="mt-2 glass-button-primary w-full px-4 py-1.5 text-sm disabled:opacity-60 inline-flex items-center justify-center gap-2"
             disabled={missingNames.length > 0 || creatingBulk}
             onClick={async () => {
+              let rowIndex = 0;
               try {
                 setCreatingBulk(true);
                 const ets = await listEventTeams(eventId);
@@ -166,16 +177,19 @@ export default function ScheduleTab({ eventId, teams, eventTeams, refreshMatches
                 for (const r of importRows) {
                   const aId = allowedMap.get(r.teamA.toLowerCase());
                   const bId = allowedMap.get(r.teamB.toLowerCase());
-                  if (!aId || !bId) continue;
-                  const payload: NewMatch = { eventId, teamAId: aId, teamBId: bId, scheduledAt: r.scheduledAt, venue: r.venue, status: r.status };
-                  await createMatch(payload);
+                  if (aId && bId) {
+                    const payload: NewMatch = { eventId, teamAId: aId, teamBId: bId, scheduledAt: r.scheduledAt, venue: r.venue, status: r.status };
+                    await createMatch(payload);
+                  }
+                  rowIndex++;
                 }
                 setImportRows(null);
                 setMissingNames([]);
                 showToast("Matches created", "success");
                 await refreshMatches();
-              } catch {
-                showToast("Failed to create matches", "error");
+              } catch (err) {
+                console.error("ScheduleTab: bulk match import failed", err);
+                showToast(`Failed to import matches at row ${rowIndex + 1}: ${errorMessage(err)}`, "error");
               } finally {
                 setCreatingBulk(false);
               }

--- a/src/component/tournament/admin/TeamsTab.tsx
+++ b/src/component/tournament/admin/TeamsTab.tsx
@@ -7,6 +7,7 @@ import { parseTeamsXlsx, type ParsedTeamRow } from "../../../tournament/importer
 import useToast from "../../../hook/useToast";
 import Toast from "../../common/Toast";
 import { TailSpin } from "react-loader-spinner";
+import { errorMessage } from "../../../services/error";
 
 type Props = {
   teams: Team[];
@@ -31,6 +32,7 @@ export default function TeamsTab({ teams, refreshTeams, eventId, refreshEventTea
   const [creating, setCreating] = useState(false);
   const [teamActionId, setTeamActionId] = useState<string | null>(null);
   const [importing, setImporting] = useState(false);
+  const [savingOverride, setSavingOverride] = useState(false);
 
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
@@ -48,15 +50,19 @@ export default function TeamsTab({ teams, refreshTeams, eventId, refreshEventTea
               disabled={creating}
               className="glass-button-primary w-full px-4 py-2 inline-flex items-center justify-center gap-2 disabled:opacity-60"
               onClick={async () => {
-                if (!name.trim()) return;
+                if (!name.trim()) {
+                  showToast("Team name is required.", "error");
+                  return;
+                }
                 try {
                   setCreating(true);
                   await createTeam({ name, short: short || undefined, logoUrl: logoUrl || undefined });
                   showToast("Team created", "success");
                   setName(""); setShort(""); setLogoUrl("");
                   await refreshTeams();
-                } catch {
-                  showToast("Failed to create team", "error");
+                } catch (err) {
+                  console.error("TeamsTab: createTeam failed", err);
+                  showToast(errorMessage(err), "error");
                 } finally {
                   setCreating(false);
                 }
@@ -82,8 +88,9 @@ export default function TeamsTab({ teams, refreshTeams, eventId, refreshEventTea
                       await updateTeam(t.id, { name: t.name });
                       showToast("Team updated", "success");
                       await refreshTeams();
-                    } catch {
-                      showToast("Failed to update team", "error");
+                    } catch (err) {
+                      console.error("TeamsTab: updateTeam failed", err);
+                      showToast(errorMessage(err), "error");
                     } finally {
                       setTeamActionId(null);
                     }
@@ -100,8 +107,9 @@ export default function TeamsTab({ teams, refreshTeams, eventId, refreshEventTea
                       await deleteTeam(t.id);
                       showToast("Team deleted", "success");
                       await refreshTeams();
-                    } catch {
-                      showToast("Failed to delete team", "error");
+                    } catch (err) {
+                      console.error("TeamsTab: deleteTeam failed", err);
+                      showToast(errorMessage(err), "error");
                     } finally {
                       setTeamActionId(null);
                     }
@@ -127,8 +135,9 @@ export default function TeamsTab({ teams, refreshTeams, eventId, refreshEventTea
               const rows = await parseTeamsXlsx(file);
               setImportTeamRows(rows);
               showToast(`Parsed ${rows.length} rows`, "success");
-            } catch {
-              showToast("Failed to parse Excel", "error");
+            } catch (err) {
+              console.error("TeamsTab: parseTeamsXlsx failed", err);
+              showToast(`Failed to parse Excel: ${errorMessage(err)}`, "error");
             } finally {
               setImporting(false);
             }
@@ -154,32 +163,41 @@ export default function TeamsTab({ teams, refreshTeams, eventId, refreshEventTea
                       byKey.set(t.name.toLowerCase(), t);
                       if (t.short) byKey.set(t.short.toLowerCase(), t);
                     }
-                    for (const row of importTeamRows) {
-                      const keyName = row.name.toLowerCase();
-                      const keyShort = row.short?.toLowerCase();
-                      let t = byKey.get(keyName) || (keyShort ? byKey.get(keyShort) : undefined);
-                      if (!t) {
-                        const id = await createTeam({ name: row.name, short: row.short, logoUrl: row.logoUrl });
-                        t = { id, name: row.name, short: row.short, logoUrl: row.logoUrl };
-                        byKey.set(keyName, t);
-                        if (keyShort) byKey.set(keyShort, t);
-                      } else {
-                        // update short/logo if provided (optional)
-                        const patch: Partial<{ name: string; short?: string; logoUrl?: string }> = {};
-                        if (row.short && row.short !== t.short) patch.short = row.short;
-                        if (row.logoUrl && row.logoUrl !== t.logoUrl) patch.logoUrl = row.logoUrl;
-                        if (Object.keys(patch).length) await updateTeam(t.id, patch);
+                    let rowIndex = 0;
+                    try {
+                      for (const row of importTeamRows) {
+                        const keyName = row.name.toLowerCase();
+                        const keyShort = row.short?.toLowerCase();
+                        let t = byKey.get(keyName) || (keyShort ? byKey.get(keyShort) : undefined);
+                        if (!t) {
+                          const id = await createTeam({ name: row.name, short: row.short, logoUrl: row.logoUrl });
+                          t = { id, name: row.name, short: row.short, logoUrl: row.logoUrl };
+                          byKey.set(keyName, t);
+                          if (keyShort) byKey.set(keyShort, t);
+                        } else {
+                          // update short/logo if provided (optional)
+                          const patch: Partial<{ name: string; short?: string; logoUrl?: string }> = {};
+                          if (row.short && row.short !== t.short) patch.short = row.short;
+                          if (row.logoUrl && row.logoUrl !== t.logoUrl) patch.logoUrl = row.logoUrl;
+                          if (Object.keys(patch).length) await updateTeam(t.id, patch);
+                        }
+                        if (alsoAddToEvent && t) {
+                          await upsertEventTeam({ eventId, teamId: t.id, short: row.short, logoOverride: row.logoUrl, group: row.group, seed: row.seed });
+                        }
+                        rowIndex++;
                       }
-                      if (alsoAddToEvent && t) {
-                        await upsertEventTeam({ eventId, teamId: t.id, short: row.short, logoOverride: row.logoUrl, group: row.group, seed: row.seed });
-                      }
+                    } catch (err) {
+                      console.error("TeamsTab: bulk team import failed", err);
+                      showToast(
+                        `Import failed at row ${rowIndex + 1} ("${importTeamRows[rowIndex]?.name ?? "?"}") after ${rowIndex} succeeded: ${errorMessage(err)}`,
+                        "error"
+                      );
+                      return;
                     }
                     setImportTeamRows(null);
                     showToast("Teams imported", "success");
                     await refreshTeams();
                     if (alsoAddToEvent) await refreshEventTeams();
-                  } catch {
-                    showToast("Failed to import teams", "error");
                   } finally {
                     setImporting(false);
                   }
@@ -215,15 +233,28 @@ export default function TeamsTab({ teams, refreshTeams, eventId, refreshEventTea
           </div>
           <div className="flex gap-2">
             <button
-              className="glass-button-primary flex-1 px-4 py-2"
+              disabled={savingOverride}
+              className="glass-button-primary flex-1 px-4 py-2 inline-flex items-center justify-center gap-2 disabled:opacity-60"
               onClick={async () => {
-                if (!selectedTeamId) return;
-                await upsertEventTeam({ eventId, teamId: selectedTeamId, short: ovShort || undefined, logoOverride: ovLogo || undefined, seed: seed ? Number(seed) : undefined, group: group || undefined });
-                setSelectedTeamId(""); setOvShort(""); setOvLogo(""); setSeed(""); setGroup("");
-                await refreshEventTeams();
+                if (!selectedTeamId) {
+                  showToast("Select a team first.", "error");
+                  return;
+                }
+                try {
+                  setSavingOverride(true);
+                  await upsertEventTeam({ eventId, teamId: selectedTeamId, short: ovShort || undefined, logoOverride: ovLogo || undefined, seed: seed ? Number(seed) : undefined, group: group || undefined });
+                  showToast("Team override saved", "success");
+                  setSelectedTeamId(""); setOvShort(""); setOvLogo(""); setSeed(""); setGroup("");
+                  await refreshEventTeams();
+                } catch (err) {
+                  console.error("TeamsTab: upsertEventTeam (override) failed", err);
+                  showToast(errorMessage(err), "error");
+                } finally {
+                  setSavingOverride(false);
+                }
               }}
             >
-              Add / Update
+              {savingOverride && <TailSpin color={SPINNER_COLOR} height={16} width={16} />}Add / Update
             </button>
           </div>
         </div>

--- a/src/services/error.ts
+++ b/src/services/error.ts
@@ -11,11 +11,13 @@ export function toServiceError(e: unknown, context: string): Error {
   return new Error(`${context}${code}: ${msg}`);
 }
 
-export async function wrapService<T>(promise: Promise<T>, context: string): Promise<T> {
-  try {
-    return await promise;
-  } catch (e) {
-    console.error(context, e);
-    throw toServiceError(e, context);
-  }
+// Extracts a human-readable message from a caught value for display in a
+// toast. Falls through plain-object/string shapes since not every rejection
+// is an Error instance (e.g. a raw string throw or a Supabase-like object).
+export function errorMessage(e: unknown, fallback = "Something went wrong."): string {
+  if (e instanceof Error && e.message) return e.message;
+  const pe = e as { message?: string } | undefined;
+  if (pe?.message) return String(pe.message);
+  if (typeof e === "string" && e) return e;
+  return fallback;
 }

--- a/src/services/eventService.ts
+++ b/src/services/eventService.ts
@@ -1,6 +1,6 @@
 import { EventProps } from '../types';
 import { supabase } from './supabaseClient';
-import { wrapService } from './error';
+import { toServiceError } from './error';
 
 // Validates a raw `events` row before it's trusted as an EventProps. Takes
 // `unknown` rather than `any` so the typeof checks below are what actually
@@ -35,36 +35,36 @@ const toEvent = (docData: unknown): EventProps | undefined => {
   return undefined;
 };
 
-export const getEvents = async () =>
-  wrapService<EventProps[]>(
-    (async () => {
-      const { data, error } = await supabase.from('events').select('*');
-      if (error) throw error;
-      const events: EventProps[] = [];
-      (data ?? []).forEach((row) => {
-        const event = toEvent(row);
-        if (event) events.push(event);
-      });
-      return events;
-    })(),
-    'Failed to fetch events'
-  );
+export const getEvents = async (): Promise<EventProps[]> => {
+  try {
+    const { data, error } = await supabase.from('events').select('*');
+    if (error) throw error;
+    const events: EventProps[] = [];
+    (data ?? []).forEach((row) => {
+      const event = toEvent(row);
+      if (event) events.push(event);
+    });
+    return events;
+  } catch (e) {
+    throw toServiceError(e, 'Failed to fetch events');
+  }
+};
 
-export const addEvent = async (event: Omit<EventProps, 'id'>) =>
-  wrapService<string>(
-    (async () => {
-      const { data, error } = await supabase.from('events').insert(event).select('id').single();
-      if (error) throw error;
-      return data.id as string;
-    })(),
-    'Failed to add event'
-  );
+export const addEvent = async (event: Omit<EventProps, 'id'>): Promise<string> => {
+  try {
+    const { data, error } = await supabase.from('events').insert(event).select('id').single();
+    if (error) throw error;
+    return data.id as string;
+  } catch (e) {
+    throw toServiceError(e, 'Failed to add event');
+  }
+};
 
-export const deleteEvent = async (id: string) =>
-  wrapService<void>(
-    (async () => {
-      const { error } = await supabase.from('events').delete().eq('id', id);
-      if (error) throw error;
-    })(),
-    'Failed to delete event'
-  );
+export const deleteEvent = async (id: string): Promise<void> => {
+  try {
+    const { error } = await supabase.from('events').delete().eq('id', id);
+    if (error) throw error;
+  } catch (e) {
+    throw toServiceError(e, 'Failed to delete event');
+  }
+};

--- a/src/utils/fileValidation.ts
+++ b/src/utils/fileValidation.ts
@@ -1,0 +1,20 @@
+const DEFAULT_MAX_BYTES = 5 * 1024 * 1024; // 5MB — adjust if the Supabase Storage bucket limit differs
+
+// Returns an error message if the file fails validation, or null if it's valid.
+export function validateImageFile(file: File, maxBytes: number = DEFAULT_MAX_BYTES): string | null {
+  if (!file.type.startsWith("image/")) return `"${file.name}" is not an image file.`;
+  if (file.size > maxBytes) return `"${file.name}" is larger than ${(maxBytes / (1024 * 1024)).toFixed(0)}MB.`;
+  return null;
+}
+
+export function validateUploadFile(
+  file: File,
+  allowedPrefixes: string[],
+  maxBytes: number = DEFAULT_MAX_BYTES
+): string | null {
+  if (!allowedPrefixes.some((prefix) => file.type.startsWith(prefix))) {
+    return `"${file.name}" is not an accepted file type.`;
+  }
+  if (file.size > maxBytes) return `"${file.name}" is larger than ${(maxBytes / (1024 * 1024)).toFixed(0)}MB.`;
+  return null;
+}


### PR DESCRIPTION
## Summary
- Adds client-side validation (file type + size) for image/flyer uploads across Event, Gallery, Homepage, and News forms via a new shared `src/utils/fileValidation.ts`
- Replaces generic "Failed to X" toasts with `errorMessage()` (in `src/services/error.ts`), which surfaces the actual error returned by Supabase/service calls instead of a canned string — applied across the tournament admin tabs (Matches/Schedule/Teams) and event/gallery/homepage/news forms and lists
- `eventService.ts` drops the now-unused `wrapService` wrapper in favor of the existing `toServiceError` helper

This work predates and is unrelated to the four PRs merged earlier today (#28–#31), which only touched UI/mobile-layout files.

## Test plan
- [x] `npx tsc --noEmit` passes
- [ ] Upload an oversized or wrong-type image/flyer on Event/Gallery/Homepage/News admin forms and confirm a validation toast appears instead of a silent failure
- [ ] Trigger a backend error (e.g. bad network) on one of the admin actions and confirm the toast shows the real error message rather than a generic one

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F4eZHjheaV4yJdjrAwe3sm